### PR TITLE
More helpful rendering of stale snapshots

### DIFF
--- a/Sources/SnapshotTesting/SnapshotTesting.swift
+++ b/Sources/SnapshotTesting/SnapshotTesting.swift
@@ -106,7 +106,7 @@ private var trackSnapshots = {
     let stale = staleSnapshots.flatMap { $1 }
     let count = stale.count
     guard count > 0 else { return }
-    let list = stale.map { "- \($0.path.debugDescription)" }.sorted().joined(separator: "\n")
+    let list = stale.map { "  \($0.path.debugDescription)" }.sorted().joined(separator: " \\\n")
     print("Found \(count) stale snapshot\(count == 1 ? "" : "s"):\n\n\(list)")
   }
 }()


### PR DESCRIPTION
Right now we get a list like this:

```
- "/path/to/my/snapshot"
- "/path/to/my/other/snapshot"
```

This isn't super actionable. I've changed the formatting to this:

```
  "/path/to/my/snapshot" \
  "/path/to/my/other/snapshot"
```

That way we can copy these lines and paste them after an `rm` in a console.