### PR TITLE
Collect test artifacts in buddybuild's dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+buddybuild_artifacts

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem 'xcpretty', '~> 0.2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,15 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    rouge (2.0.7)
+    xcpretty (0.2.8)
+      rouge (~> 2.0.7)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  xcpretty (~> 0.2.8)
+
+BUNDLED WITH
+   1.16.0.pre.3

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
-xcodebuild test -scheme SnapshotTesting-Package -destination platform="macOS"
-xcodebuild test -scheme SnapshotTesting-Package -destination platform="iOS Simulator,name=iPhone 8,OS=11.2"
+mkdir -p buddybuild_artifacts/SwiftTests
+
+xcodebuild test -scheme SnapshotTesting-Package -destination platform="macOS" | bundle exec xcpretty -r junit -o buddybuild_artifacts/SwiftTests/output-mac.xml
+
+xcodebuild test -scheme SnapshotTesting-Package -destination platform="iOS Simulator,name=iPhone 8,OS=11.2" | bundle exec xcpretty -r junit -o buddybuild_artifacts/SwiftTests/output-ios.xml

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+bundle install --quiet
 mkdir -p buddybuild_artifacts/SwiftTests
 
 xcodebuild test -scheme SnapshotTesting-Package -destination platform="macOS" | bundle exec xcpretty -r junit -o buddybuild_artifacts/SwiftTests/output-mac.xml


### PR DESCRIPTION
This collects the test reports formatted in the JUnit format and display them in the dashboard.
More info: https://www.buddybuild.com/blog/custom-test-reporting

![screenshot-2017-11-20 snapshottesting buddybuild](https://user-images.githubusercontent.com/48797/33042580-4cccd260-ce10-11e7-9188-8e201dec02ed.png)
