### PR TITLE
Cocoapods support

### DIFF
--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -1,0 +1,30 @@
+#
+# Be sure to run `pod lib lint SnapshotTesting.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'SnapshotTesting'
+  s.version          = '0.1.0'
+  s.summary          = 'Tests that save and assert against reference data'
+
+
+  s.description      = <<-DESC
+    Automatically record app data into test assertions. Snapshot tests capture the entirety of a data structure and cover far more surface area than a typical unit test.
+                       DESC
+
+  s.homepage         = 'https://github.com/pointfreeco/swift-snapshot-testing'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors          = { 'Brandon Williams' => 'mbw234@gmail.com' , 
+                         'Stephen Celis' => 'me@stephencelis.com' }
+  s.social_media_url = 'https://twitter.com/pointfreeco'
+  s.source           = { :git => 'https://github.com/pointfreeco/swift-snapshot-testing.git', :tag => s.version.to_s }
+
+  s.ios.deployment_target = '8.0'
+  s.source_files = 'Sources/**/*'
+  s.frameworks = 'UIKit', 'XCTest', 'WebKit'
+  
+end

--- a/Sources/SnapshotTesting/Diffable.swift
+++ b/Sources/SnapshotTesting/Diffable.swift
@@ -1,4 +1,6 @@
-import Diff
+#if !COCOAPODS
+    import Diff
+#endif
 import Foundation
 import XCTest
 

--- a/Sources/SnapshotTesting/WebKit.swift
+++ b/Sources/SnapshotTesting/WebKit.swift
@@ -1,5 +1,8 @@
 #if os(iOS) || os(macOS)
-  import WKSnapshotConfigurationShim
+  #if !COCOAPODS
+    import WKSnapshotConfigurationShim
+  #endif
+
   import XCTest
 
   @available(iOS 11.0, macOS 10.13, *)


### PR DESCRIPTION
I've been playing with your library and it's awesome. I have added support for cocoapods in order to be able to play around with it in my iOS project. I know it's still in early development and the API may change a lot before been stable, this is just the initial implementation. 

Lastly I still have two warnings while running `pod lib lint SnapshotTesting.podspec --verbose`, and I don't know how to fix it right now. Any help would be appreciated 

```
** BUILD SUCCEEDED **

   Testing with xcodebuild. 
 -> SnapshotTesting (0.1.0)
    - NOTE  | xcodebuild:  <module-includes>:1:9: note: in file included from <module-includes>:1:
    - NOTE  | xcodebuild:  /privateTarget Support Files/SnapshotTesting/SnapshotTesting-umbrella.h:13:9: note: in file included from /privateTarget Support Files/SnapshotTesting/SnapshotTesting-umbrella.h:13:
    - WARN  | xcodebuild:  /Users/guilhermesampaio/Dev/OSS/swift-snapshot-testing/Sources/WKSnapshotConfigurationShim/include/WKSnapshotConfigurationShim.h:2:2: warning: missing submodule 'WebKit.WKSnapshotConfiguration'
    - NOTE  | xcodebuild:  /Users/guilhermesampaio/Library/Developer/Xcode/DerivedData/App-ghdrndgqqxoolwbxhjjzystbddvp/Build/Products/Release-iphonesimulator/SnapshotTesting/SnapshotTesting.framework/Headers/SnapshotTesting-umbrella.h:13:9: note: in file included from /Users/guilhermesampaio/Library/Developer/Xcode/DerivedData/App-ghdrndgqqxoolwbxhjjzystbddvp/Build/Products/Release-iphonesimulator/SnapshotTesting/SnapshotTesting.framework/Headers/SnapshotTesting-umbrella.h:13:
    - WARN  | xcodebuild:  /Users/guilhermesampaio/Library/Developer/Xcode/DerivedData/App-ghdrndgqqxoolwbxhjjzystbddvp/Build/Products/Release-iphonesimulator/SnapshotTesting/SnapshotTesting.framework/Headers/WKSnapshotConfigurationShim.h:2:2: warning: missing submodule 'WebKit.WKSnapshotConfiguration'
```

Thanks for all the work on it.