### PR TITLE
Update source_files spec to ignore .plist files

### DIFF
--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/pointfreeco/swift-snapshot-testing.git', :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.{swift,h,m}'
   s.frameworks = 'UIKit', 'XCTest', 'WebKit'
   
 end


### PR DESCRIPTION
In order to support new xcode build system you cannot include .plist into compile source build phase.

Otherwise you are getting this error:
 

> error: unexpected duplicate task: CopyPlistFile /Users/radeknovak/Library/Developer/Xcode/DerivedData//Build/Products/Alpha-iphonesimulator/SnapshotTesting/SnapshotTesting.framework/Info.plist /Users//Pods/Target Support Files/SnapshotTesting/Info.plist (in target 'SnapshotTesting')