### PR TITLE
Use Device UIKit scale factor for loading images from file

### DIFF
--- a/Sources/SnapshotTesting/UIKit.swift
+++ b/Sources/SnapshotTesting/UIKit.swift
@@ -39,7 +39,7 @@ extension UIImage: Diffable {
   }
 
   public static func fromDiffableData(_ diffableData: Data) -> Self {
-    return self.init(data: diffableData, scale: 2.0)!
+    return self.init(data: diffableData, scale: UIScreen.main.scale)!
   }
 
   public var diffableData: Data {


### PR DESCRIPTION
This fixes screenshot comparisons failing on iPhone Plus models that use a
3x scale factor instead of the more common 2x scale factor