### PR TITLE
Truncate Error Output

### DIFF
--- a/Sources/SnapshotTesting/Diffable.swift
+++ b/Sources/SnapshotTesting/Diffable.swift
@@ -53,7 +53,10 @@ extension String: Diffable {
       fst.split(separator: "\n", omittingEmptySubsequences: false).map(String.init),
       snd.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
     ))
-    let failure = hunks.flatMap { [$0.patchMark] + $0.lines }.joined(separator: "\n")
+    let failure = hunks.flatMap { [$0.patchMark] + $0.lines }
+      .prefix(5)
+      .map { $0.prefix(80) }
+      .joined(separator: "\n")
 
     return ("Diff: …\n\n\(failure)", [.init(string: failure)])
   }


### PR DESCRIPTION
The current way of capturing _everything_ when recorded, and of the entire diff output makes Xcode just crawl. This should speed things up.