### PR TITLE
Witness Cleanup

### DIFF
--- a/Sources/SnapshotTesting/Strategy/NSView.swift
+++ b/Sources/SnapshotTesting/Strategy/NSView.swift
@@ -8,7 +8,7 @@ extension Strategy {
       precondition(!($0 is WKWebView), """
 WKWebView must be snapshot using the "webView" strategy.
 
-    assertSnapshot(view, with: .webView)
+    assertSnapshot(matching: view, with: .webView)
 """)
 
       let image = NSImage(data: $0.dataWithPDF(inside: $0.bounds))!

--- a/Sources/SnapshotTesting/Strategy/NSView.swift
+++ b/Sources/SnapshotTesting/Strategy/NSView.swift
@@ -4,10 +4,14 @@ import WebKit
 
 extension Strategy {
   public static var view: Strategy<NSView, NSImage> {
-    return Strategy.image.contramap { view in
-      precondition(!(view is WKWebView), "TODO")
+    return Strategy.image.contramap {
+      precondition(!($0 is WKWebView), """
+WKWebView must be snapshot using the "webView" strategy.
 
-      let image = NSImage(data: view.dataWithPDF(inside: view.bounds))!
+    assertSnapshot(view, with: .webView)
+""")
+
+      let image = NSImage(data: $0.dataWithPDF(inside: $0.bounds))!
       let scale = NSScreen.main!.backingScaleFactor
       image.size = .init(width: image.size.width * 2.0 / scale, height: image.size.height * 2.0 / scale)
       return image

--- a/Sources/SnapshotTesting/Strategy/UIView.swift
+++ b/Sources/SnapshotTesting/Strategy/UIView.swift
@@ -8,7 +8,7 @@ extension Strategy {
       precondition(!($0 is WKWebView), """
 WKWebView must be snapshot using the "webView" strategy.
 
-    assertSnapshot(view, with: .webView)
+    assertSnapshot(matching: view, with: .webView)
 """)
 
       return $0.layer

--- a/Sources/SnapshotTesting/Strategy/UIView.swift
+++ b/Sources/SnapshotTesting/Strategy/UIView.swift
@@ -5,7 +5,12 @@ import WebKit
 extension Strategy {
   public static var view: Strategy<UIView, UIImage> {
     return Strategy.layer.contramap {
-      precondition(!($0 is WKWebView), "TODO")
+      precondition(!($0 is WKWebView), """
+WKWebView must be snapshot using the "webView" strategy.
+
+    assertSnapshot(view, with: .webView)
+""")
+
       return $0.layer
     }
   }


### PR DESCRIPTION
It's not super-generic. It prints a `ksdiff`-specific string and only restores the ability to save a basic artifact for diffing locally. As far as CI is concerned it only records the newest thing but doesn't track the diff.

We really oughta take all the `Attachment` artifacts and save em all, but we can do that later.