### PR TITLE
Add conditional difftooling

### DIFF
--- a/Sources/Diff/Diff.swift
+++ b/Sources/Diff/Diff.swift
@@ -42,8 +42,8 @@ public func diff<A: Hashable>(_ fst: [A], _ snd: [A]) -> [Difference<A>] {
   }
 }
 
-private let minus = "−"
-private let plus = "+"
+public let minus = "−"
+public let plus = "+"
 private let figureSpace = "\u{2007}"
 
 public struct Hunk {

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -2,7 +2,8 @@ import XCTest
 
 open class SnapshotTestCase: XCTestCase {
   private var counter = 1
-  public var record = false
+  open var record = false
+  open var diffTool: String? = nil
 
   public func assertSnapshot<A: DefaultDiffable>(
     matching snapshot: A,
@@ -81,7 +82,7 @@ open class SnapshotTestCase: XCTestCase {
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
         try strategy.diffable.to(diffable).write(to: snapshotFileUrl)
-        XCTFail("Recorded snapshot to \(snapshotFileUrl)", file: file, line: line)
+        XCTFail("Recorded snapshot: …\n\n\"\(snapshotFileUrl.path)\"", file: file, line: line)
         return
       }
 
@@ -109,12 +110,12 @@ open class SnapshotTestCase: XCTestCase {
         #endif
       }
 
+      let message = [
+        failure.trimmingCharacters(in: .whitespacesAndNewlines),
+        self.diffTool.map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+      ]
       XCTFail(
-        """
-\(failure.trimmingCharacters(in: .whitespacesAndNewlines))
-
-ksdiff "\(snapshotFileUrl.path)" "\(failedSnapshotFileUrl.path)"
-""",
+        message.compactMap { $0 }.joined(separator: "\n\n"),
         file: file,
         line: line
       )

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -1,3 +1,4 @@
+import Diff
 import XCTest
 
 open class SnapshotTestCase: XCTestCase {
@@ -112,7 +113,9 @@ open class SnapshotTestCase: XCTestCase {
 
       let message = [
         failure.trimmingCharacters(in: .whitespacesAndNewlines),
-        self.diffTool.map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+        self.diffTool
+          .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+          ?? "@\(Diff.minus)\n\"\(failedSnapshotFileUrl.path)\"\n@\(Diff.plus)\n\"\(snapshotFileUrl.path)\""
       ]
       XCTFail(
         message.compactMap { $0 }.joined(separator: "\n\n"),

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -111,17 +111,15 @@ open class SnapshotTestCase: XCTestCase {
         #endif
       }
 
-      let message = [
-        failure.trimmingCharacters(in: .whitespacesAndNewlines),
-        self.diffTool
-          .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
-          ?? "@\(Diff.minus)\n\"\(failedSnapshotFileUrl.path)\"\n@\(Diff.plus)\n\"\(snapshotFileUrl.path)\""
-      ]
-      XCTFail(
-        message.compactMap { $0 }.joined(separator: "\n\n"),
-        file: file,
-        line: line
-      )
+      let diffMessage = self.diffTool
+        .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+        ?? "@\(Diff.minus)\n\"\(failedSnapshotFileUrl.path)\"\n@\(Diff.plus)\n\"\(snapshotFileUrl.path)\""
+      let message = """
+\(failure.trimmingCharacters(in: .whitespacesAndNewlines))
+
+\(diffMessage)
+"""
+      XCTFail(message, file: file, line: line)
     } catch {
       XCTFail(error.localizedDescription, file: file, line: line)
     }

--- a/Sources/SnapshotTesting/Strategy/Data.swift
+++ b/Sources/SnapshotTesting/Strategy/Data.swift
@@ -16,7 +16,10 @@ extension Strategy {
       pathExtension: nil,
       diffable: .init(to: { $0 }, fro: { $0 }) { old, new in
         guard old != new else { return nil }
-        return ("Expected \(new) to match \(old)", [])
+        let message = old.count == new.count
+          ? "Expected data to match"
+          : "Expected \(new) to match \(old)"
+        return (message, [])
       }
     )
   }

--- a/Sources/SnapshotTesting/Strategy/NSImage.swift
+++ b/Sources/SnapshotTesting/Strategy/NSImage.swift
@@ -42,8 +42,11 @@ extension Strategy {
         context.fill(.init(origin: .zero, size: maxSize))
         context.endTransparencyLayer()
         diff.unlockFocus()
+        let message = new.size == old.size
+          ? "Expected images to match"
+          : "Expected image@\(new.size) to match image@\(old.size)"
         return (
-          "Expected image@\(new.size) to match image@\(old.size)",
+          message,
           [Attachment(image: old), Attachment(image: new), Attachment(image: diff)]
         )
       }

--- a/Sources/SnapshotTesting/Strategy/UIImage.swift
+++ b/Sources/SnapshotTesting/Strategy/UIImage.swift
@@ -43,8 +43,11 @@ extension Strategy {
         context.endTransparencyLayer()
         let diff = UIGraphicsGetImageFromCurrentImageContext()!
 
+        let message = new.size == old.size
+          ? "Expected images to match"
+          : "Expected image@\(new.size) to match image@\(old.size)"
         return (
-          "Expected image@\(new.size) to match image@\(old.size)",
+          message,
           [
             .init(image: old, name: "reference"),
             .init(image: new, name: "failure"),

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -12,6 +12,7 @@ let platform = "macos"
 class SnapshotTestingTests: SnapshotTestCase {
   override func setUp() {
     super.setUp()
+    diffTool = "ksdiff"
 //    record = true
   }
 

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -12,7 +12,6 @@ let platform = "macos"
 class SnapshotTestingTests: SnapshotTestCase {
   override func setUp() {
     super.setUp()
-    diffTool = "ksdiff"
 //    record = true
   }
 


### PR DESCRIPTION
This makes `ksdiff` tooling opt-in and cleans up some error messaging.