### PR TITLE
Use ksdiff

### DIFF
--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -12,6 +12,7 @@ let platform = "macos"
 class SnapshotTestingTests: SnapshotTestCase {
   override func setUp() {
     super.setUp()
+    self.diffTool = "ksdiff"
 //    record = true
   }
 


### PR DESCRIPTION
Nicer output for inspection since we use `ksdiff`.