### PR TITLE
Improve cocoapods support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ This library should be considered alpha, and not stable. Breaking changes will h
 
 ## Installation
 
+### Swift Package Manager
+
 ```swift
 import PackageDescription
 
@@ -22,6 +24,14 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", .branch("master")),
   ]
 )
+```
+
+### Cocoapods
+
+```ruby
+target 'Tests' do
+  pod 'SnapshotTesting', :git => 'https://github.com/pointfreeco/swift-snapshot-testing.git'
+end
 ```
 
 ## Usage

--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -28,5 +28,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.9"
   s.tvos.deployment_target = "9.0"
 
+  s.frameworks = 'XCTest'
+
   s.source_files  = "Sources", "Sources/**/*.swift"
 end


### PR DESCRIPTION
This PR includes 2 changes:
1 - When using the library with Cocoapods i get the following error:
`Cannot load underlying module for 'XCTest'`
A fix in the `SnapshotTesting.podspec` file was added to include the `XCTest` framework as a dependency.

2- Minor improvement in the README to make more explicit the support for Cocoapods.
