### PR TITLE
Use minus sign instead of hyphen minus

### DIFF
--- a/Sources/SnapshotTesting/Diff.swift
+++ b/Sources/SnapshotTesting/Diff.swift
@@ -42,7 +42,7 @@ func diff<A: Hashable>(_ fst: [A], _ snd: [A]) -> [Difference<A>] {
   }
 }
 
-let minus = "−"
+let minus = "-"
 let plus = "+"
 private let figureSpace = "\u{2007}"
 


### PR DESCRIPTION
Currently if you copy and paste the diff from a failure message into something that can syntax highlight diffs, the deletions will not render. For example:

```diff
−a
+b
```

This is because we are using a hyphen minus instead of a minus sign. If we change to a regular minus sign it works:

```diff
-a
+b
```