### PR TITLE
Remove DefaultSnapshottable

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -4,28 +4,6 @@ import XCTest
 public var diffTool: String? = nil
 public var record = false
 
-public func assertSnapshot<A: DefaultSnapshottable>(
-  matching snapshot: A,
-  named name: String? = nil,
-  record recording: Bool = false,
-  timeout: TimeInterval = 5,
-  file: StaticString = #file,
-  testName: String = #function,
-  line: UInt = #line)
-  where A.Snapshottable == A
-{
-  return assertSnapshot(
-    matching: snapshot,
-    as: A.defaultStrategy,
-    named: name,
-    record: recording,
-    timeout: timeout,
-    file: file,
-    testName: testName,
-    line: line
-  )
-}
-
 public func assertSnapshot<A, B>(
   matching value: A,
   as strategy: Strategy<A, B>,

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -6,28 +6,6 @@ open class SnapshotTestCase: XCTestCase {
   open var record = false
   open var diffTool: String? = nil
 
-  public func assertSnapshot<A: DefaultSnapshottable>(
-    matching snapshot: A,
-    named name: String? = nil,
-    record recording: Bool = false,
-    timeout: TimeInterval = 5,
-    file: StaticString = #file,
-    testName: String = #function,
-    line: UInt = #line)
-    where A.Snapshottable == A
-  {
-    return assertSnapshot(
-      matching: snapshot,
-      as: A.defaultStrategy,
-      named: name,
-      record: recording,
-      timeout: timeout,
-      file: file,
-      testName: testName,
-      line: line
-    )
-  }
-
   public func assertSnapshot<Snapshottable, Format>(
     matching value: Snapshottable,
     as strategy: Strategy<Snapshottable, Format>,

--- a/Sources/SnapshotTesting/Strategy.swift
+++ b/Sources/SnapshotTesting/Strategy.swift
@@ -57,9 +57,3 @@ extension Strategy where Snapshottable == Format {
     )
   }
 }
-
-public protocol DefaultSnapshottable {
-  associatedtype Snapshottable = Self
-  associatedtype Format
-  static var defaultStrategy: Strategy<Snapshottable, Format> { get }
-}

--- a/Sources/SnapshotTesting/Strategy/CALayer.swift
+++ b/Sources/SnapshotTesting/Strategy/CALayer.swift
@@ -19,10 +19,6 @@ extension Strategy where Snapshottable == CALayer, Format == NSImage {
     }
   }
 }
-
-extension CALayer: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<CALayer, NSImage> = .image
-}
 #elseif os(iOS) || os(tvOS)
 import UIKit
 
@@ -40,9 +36,5 @@ extension Strategy where Snapshottable == CALayer, Format == UIImage {
       }
     }
   }
-}
-
-extension CALayer: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<CALayer, UIImage> = .image
 }
 #endif

--- a/Sources/SnapshotTesting/Strategy/Data.swift
+++ b/Sources/SnapshotTesting/Strategy/Data.swift
@@ -24,7 +24,3 @@ extension Strategy where Snapshottable == Data, Format == Data {
     )
   }
 }
-
-extension Data: DefaultSnapshottable {
-  public static let defaultStrategy: SimpleStrategy = .data
-}

--- a/Sources/SnapshotTesting/Strategy/NSImage.swift
+++ b/Sources/SnapshotTesting/Strategy/NSImage.swift
@@ -35,10 +35,6 @@ extension Strategy where Snapshottable == NSImage, Format == NSImage {
   }
 }
 
-extension NSImage: DefaultSnapshottable {
-  public static let defaultStrategy: SimpleStrategy = .image
-}
-
 private func NSImagePNGRepresentation(_ image: NSImage) -> Data? {
   guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }
   let rep = NSBitmapImageRep(cgImage: cgImage)

--- a/Sources/SnapshotTesting/Strategy/NSViewController.swift
+++ b/Sources/SnapshotTesting/Strategy/NSViewController.swift
@@ -24,8 +24,4 @@ extension Strategy where Snapshottable == NSViewController, Format == String {
     return Strategy<NSView, String>.recursiveDescription.pullback { $0.view }
   }
 }
-
-extension NSViewController: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<NSViewController, NSImage> = .image
-}
 #endif

--- a/Sources/SnapshotTesting/Strategy/String.swift
+++ b/Sources/SnapshotTesting/Strategy/String.swift
@@ -4,10 +4,6 @@ extension Strategy where Snapshottable == String, Format == String {
   public static let lines = Strategy(pathExtension: "txt", diffable: .lines)
 }
 
-extension String: DefaultSnapshottable {
-  public static let defaultStrategy: SimpleStrategy = .lines
-}
-
 extension Diffable where A == String {
   public static let lines = Diffable(
     to: { Data($0.utf8) },

--- a/Sources/SnapshotTesting/Strategy/UIImage.swift
+++ b/Sources/SnapshotTesting/Strategy/UIImage.swift
@@ -39,10 +39,6 @@ extension Strategy where Snapshottable == UIImage, Format == UIImage {
   }
 }
 
-extension UIImage: DefaultSnapshottable {
-  public static let defaultStrategy: SimpleStrategy = .image
-}
-
 private func compare(_ old: UIImage, _ new: UIImage, precision: Float) -> Bool {
   guard let oldCgImage = old.cgImage else { return false }
   guard let newCgImage = new.cgImage else { return false }

--- a/Sources/SnapshotTesting/Strategy/UIViewController.swift
+++ b/Sources/SnapshotTesting/Strategy/UIViewController.swift
@@ -44,8 +44,4 @@ extension Strategy where Snapshottable == UIViewController, Format == String {
     return Strategy<UIView, String>.recursiveDescription.pullback { $0.view }
   }
 }
-
-extension UIViewController: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<UIViewController, UIImage> = .image
-}
 #endif

--- a/Sources/SnapshotTesting/Strategy/View.swift
+++ b/Sources/SnapshotTesting/Strategy/View.swift
@@ -55,10 +55,6 @@ extension Strategy where Snapshottable == NSView, Format == String {
     }
   }
 }
-
-extension NSView: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<NSView, NSImage> = .image
-}
 #elseif os(iOS) || os(tvOS)
 extension Strategy where Snapshottable == UIView, Format == UIImage {
   public static var image: Strategy {
@@ -128,10 +124,6 @@ extension Strategy where Snapshottable == UIView, Format == String {
       )
     }
   }
-}
-
-extension UIView: DefaultSnapshottable {
-  public static let defaultStrategy: Strategy<UIView, UIImage> = .image
 }
 
 func traitController(

--- a/Tests/SnapshotTestingTests/SnapshotTestCaseTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestCaseTests.swift
@@ -62,7 +62,7 @@ class SnapshotTestCaseTests: TestCase {
   func testUIView() {
     #if os(iOS)
     let view = UIButton(type: .contactAdd)
-    assertSnapshot(matching: view)
+    assertSnapshot(matching: view, as: .image)
     assertSnapshot(matching: view, as: .recursiveDescription)
     #endif
   }
@@ -86,7 +86,7 @@ class SnapshotTestCaseTests: TestCase {
       view.addSubview(webView)
       view.addSubview(skView)
 
-      assertSnapshot(matching: view, named: platform)
+      assertSnapshot(matching: view, as: .image, named: platform)
     }
     #endif
   }
@@ -98,7 +98,7 @@ class SnapshotTestCaseTests: TestCase {
     button.title = "Push Me"
     button.sizeToFit()
     if #available(macOS 10.14, *) {
-      assertSnapshot(matching: button)
+      assertSnapshot(matching: button, as: .image)
       assertSnapshot(matching: button, as: .recursiveDescription)
     }
     #endif
@@ -113,7 +113,7 @@ class SnapshotTestCaseTests: TestCase {
     let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 800, height: 600))
     webView.loadHTMLString(html, baseURL: nil)
     if #available(macOS 10.14, *) {
-      assertSnapshot(matching: webView, named: platform)
+      assertSnapshot(matching: webView, as: .image, named: platform)
     }
     #endif
   }
@@ -146,7 +146,11 @@ class SnapshotTestCaseTests: TestCase {
       omniLightNode.position = SCNVector3Make(10, 10, 10)
       scene.rootNode.addChildNode(omniLightNode)
 
-      assertSnapshot(matching: scene, as: .image(size: .init(width: 500, height: 500)), named: platform)
+      assertSnapshot(
+        matching: scene,
+        as: .image(size: .init(width: 500, height: 500)),
+        named: platform
+      )
     }
     #endif
   }
@@ -161,7 +165,11 @@ class SnapshotTestCaseTests: TestCase {
       node.position = .init(x: 25, y: 25)
       scene.addChild(node)
 
-      assertSnapshot(matching: scene, as: .image(size: .init(width: 50, height: 50)), named: platform)
+      assertSnapshot(
+        matching: scene,
+        as: .image(size: .init(width: 50, height: 50)),
+        named: platform
+      )
     }
     #endif
   }


### PR DESCRIPTION
This convenience may not really be pulling its weight. Overloads always make error messages worse and being explicit with the strategy is kinda nice and self-documenting.

We can always revisit this in the future, but let's keep the API surface area more lean for now.