### PR TITLE
Add back related tools section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ dependencies: [
   - **SceneKit, SpriteKit, and WebKit support.** Most snapshot testing libraries don't support these view subclasses.
   - **`Codable` support**. Snapshot encodable data structures into their [JSON](Documentation/Available-Snapshot-Strategies.md#json) and [property list](Documentation/Available-Snapshot-Strategies.md#plist) representations.
   - **Custom diff tool integration**.
+  
+## Related Tools
+
+  - [`FBSnapshotTestCase`](https://github.com/facebook/ios-snapshot-test-case) helped introduce screen shot testing to a broad audience in the iOS community. Experience with it inspired the creation of this library.
+
+  - [`Jest`](http://facebook.github.io/jest/) brought generalized snapshot testing to the front-end with a polished user experience. Several features of this library (diffing, tracking outdated snapshots) were directly influenced.
 
 ## Learn More
 


### PR DESCRIPTION
Looks like during our documentation/readme rewrites we lost [this section](https://github.com/pointfreeco/swift-snapshot-testing/commit/b4081b7f14eac7d0540b6cf6a4caf57816d7a8c2). Adding back.