### PR TITLE
Use official Swift docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swift:421
+FROM swift:4.2
 
 WORKDIR /package
 


### PR DESCRIPTION
Since the docker images for Swift moved to Apple's GitHub organization the `Dockerfile` can be simplified to use the official image. (The [4.2 tag](https://github.com/apple/swift-docker/blob/master/4.2/Dockerfile) has Swift 4.2.1 installed).