### PR TITLE
Show previous diff message when recording

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -119,10 +119,15 @@ public func verifySnapshot<Value, Format>(
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
+        let diffMessage = (try? Data(contentsOf: snapshotFileUrl))
+          .flatMap { data in snapshotting.diffing.diff(snapshotting.diffing.fromData(data), diffable) }
+          .map { diff, _ in diff.trimmingCharacters(in: .whitespacesAndNewlines) }
+          ?? "Recorded: …"
+
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         return recording
           ? """
-            Record mode is on. Recorded snapshot: …
+            Record mode is on. \(diffMessage)
 
             open "\(snapshotFileUrl.path)"
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -122,7 +122,7 @@ public func verifySnapshot<Value, Format>(
         let diffMessage = (try? Data(contentsOf: snapshotFileUrl))
           .flatMap { data in snapshotting.diffing.diff(snapshotting.diffing.fromData(data), diffable) }
           .map { diff, _ in diff.trimmingCharacters(in: .whitespacesAndNewlines) }
-          ?? "Recorded: …"
+          ?? "Recorded snapshot: …"
 
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         return recording

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -70,7 +70,7 @@ open class SnapshotTestCase: XCTestCase {
       self.wait(for: [tookSnapshot], timeout: timeout)
       #endif
 
-      guard let diffing = optionalDiffable else {
+      guard let diffable = optionalDiffable else {
         XCTFail("Couldn't snapshot value", file: file, line: line)
         return
       }
@@ -105,7 +105,7 @@ open class SnapshotTestCase: XCTestCase {
       let data = try Data(contentsOf: snapshotFileUrl)
       let reference = snapshotting.diffing.fromData(data)
 
-      guard let (failure, attachments) = snapshotting.diffing.diff(reference, diffing) else {
+      guard let (failure, attachments) = snapshotting.diffing.diff(reference, diffable) else {
         return
       }
 
@@ -115,7 +115,7 @@ open class SnapshotTestCase: XCTestCase {
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
       try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
       let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
-      try snapshotting.diffing.toData(diffing).write(to: failedSnapshotFileUrl)
+      try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
 
       if !attachments.isEmpty {
         #if !os(Linux)

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -76,10 +76,15 @@ open class SnapshotTestCase: XCTestCase {
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
-        try snapshotting.diffing.toData(diffing).write(to: snapshotFileUrl)
+        let diffMessage = (try? Data(contentsOf: snapshotFileUrl))
+          .flatMap { data in snapshotting.diffing.diff(snapshotting.diffing.fromData(data), diffable) }
+          .map { diff, _ in diff.trimmingCharacters(in: .whitespacesAndNewlines) }
+          ?? "Recorded snapshot: …"
+
+        try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         let message = recording
           ? """
-            Record mode is on. Recorded snapshot: …
+            Record mode is on. \(diffMessage)
 
             open "\(snapshotFileUrl.path)"
 


### PR DESCRIPTION
Fix #28!

What an old issue. Realized it was probably a 5 minute fix and it was. Example inline failure:

<img width="843" alt="image" src="https://user-images.githubusercontent.com/658/50131565-c824b980-0250-11e9-9e2b-97fedbbe2502.png">
