### PR TITLE
Move around some failure messaging.

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -127,11 +127,11 @@ public func verifySnapshot<Value, Format>(
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         return recording
           ? """
-            Record mode is on. \(diffMessage)
+            Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
 
             open "\(snapshotFileUrl.path)"
 
-            Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
+            \(diffMessage)
             """
           : """
             No reference was found on disk. Automatically recorded snapshot: …
@@ -173,9 +173,11 @@ public func verifySnapshot<Value, Format>(
         .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
         ?? "@\(minus)\n\"\(snapshotFileUrl.path)\"\n@\(plus)\n\"\(failedSnapshotFileUrl.path)\""
       return """
-      \(failure.trimmingCharacters(in: .whitespacesAndNewlines))
+      Snapshot does not match reference.
 
       \(diffMessage)
+
+      \(failure.trimmingCharacters(in: .whitespacesAndNewlines))
       """
     } catch {
       return error.localizedDescription

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -132,7 +132,7 @@ open class SnapshotTestCase: XCTestCase {
         ?? "@\(minus)\n\"\(snapshotFileUrl.path)\"\n@\(plus)\n\"\(failedSnapshotFileUrl.path)\""
       let message = """
       Snapshot does not match reference.
-      
+
       \(diffMessage)
 
       \(failure.trimmingCharacters(in: .whitespacesAndNewlines))

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -84,11 +84,11 @@ open class SnapshotTestCase: XCTestCase {
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         let message = recording
           ? """
-            Record mode is on. \(diffMessage)
+            Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
 
             open "\(snapshotFileUrl.path)"
 
-            Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
+            \(diffMessage)
             """
           : """
             No reference was found on disk. Automatically recorded snapshot: …
@@ -131,9 +131,11 @@ open class SnapshotTestCase: XCTestCase {
         .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
         ?? "@\(minus)\n\"\(snapshotFileUrl.path)\"\n@\(plus)\n\"\(failedSnapshotFileUrl.path)\""
       let message = """
-      \(failure.trimmingCharacters(in: .whitespacesAndNewlines))
-
+      Snapshot does not match reference.
+      
       \(diffMessage)
+
+      \(failure.trimmingCharacters(in: .whitespacesAndNewlines))
       """
       XCTFail(message, file: file, line: line)
     } catch {

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -21,6 +21,6 @@ extension Diffing where Value == String {
       .flatMap { [$0.patchMark] + $0.lines }
       .joined(separator: "\n")
     let attachment = XCTAttachment(data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
-    return ("Diff: …\n\n\(failure)", [attachment])
+    return (failure, [attachment])
   }
 }


### PR DESCRIPTION
Re-prioritizing some of the failure messaging so that the shorter stuff is on top and doesn't get knocked down by the diff.

### Failure

<img width="1037" alt="messages image 3326583461" src="https://user-images.githubusercontent.com/135203/50298973-72b5fb80-044e-11e9-9891-917a24fc09b3.png">

### Record

<img width="1012" alt="messages image 3768075003" src="https://user-images.githubusercontent.com/135203/50298996-7ea1bd80-044e-11e9-95b6-60e6b6899176.png">
