### PR TITLE
Change pullback generic names

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting.swift
+++ b/Sources/SnapshotTesting/Snapshotting.swift
@@ -46,20 +46,20 @@ public struct Snapshotting<Value, Format> {
     }
   }
 
-  /// Transforms a strategy on `Value`s into a strategy on `A`s through a function `(A) -> Async<Value>`.
+  /// Transforms a strategy on `Value`s into a strategy on `Root`s through a function `(Root) -> Async<Value>`.
   ///
   /// - Parameters:
-  ///   - transform: A transform function from `A` into `Async<Value>`.
+  ///   - transform: A transform function from `Root` into `Async<Value>`.
   ///   - otherValue: A value to be transformed.
-  public func asyncPullback<A>(_ transform: @escaping (_ otherValue: A) -> Async<Value>) -> Snapshotting<A, Format> {
-    return Snapshotting<A, Format>(
+  public func asyncPullback<Root>(_ transform: @escaping (_ otherValue: Root) -> Async<Value>) -> Snapshotting<Root, Format> {
+    return Snapshotting<Root, Format>(
       pathExtension: self.pathExtension,
       diffing: self.diffing
-    ) { a0 in
+    ) { root in
       return .init { callback in
-        transform(a0).run { a in
-          self.snapshot(a).run { b in
-            callback(b)
+        transform(root).run { value in
+          self.snapshot(value).run { snapshot in
+            callback(snapshot)
           }
         }
       }
@@ -71,13 +71,13 @@ public struct Snapshotting<Value, Format> {
   /// - Parameters:
   ///   - transform: A transform function from `A` into `Value`.
   ///   - otherValue: A value to be transformed.
-  public func pullback<A>(_ transform: @escaping (_ otherValue: A) -> Value) -> Snapshotting<A, Format> {
-    return self.asyncPullback { Async(value: transform($0)) }
+  public func pullback<Root>(_ transform: @escaping (_ otherValue: Root) -> Value) -> Snapshotting<Root, Format> {
+    return self.asyncPullback { root in Async(value: transform(root)) }
   }
 }
 
 /// A snapshot strategy where the type being snapshot is also a diffable type.
-public typealias SimplySnapshotting<A> = Snapshotting<A, A>
+public typealias SimplySnapshotting<Format> = Snapshotting<Format, Format>
 
 extension Snapshotting where Value == Format {
   public init(pathExtension: String?, diffing: Diffing<Format>) {

--- a/Sources/SnapshotTesting/Snapshotting.swift
+++ b/Sources/SnapshotTesting/Snapshotting.swift
@@ -74,7 +74,7 @@ public struct Snapshotting<Value, Format> {
   ///   - transform: A transform function from `NewValue` into `Value`.
   ///   - otherValue: A value to be transformed.
   public func pullback<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Value) -> Snapshotting<NewValue, Format> {
-    return self.asyncPullback { root in Async(value: transform(root)) }
+    return self.asyncPullback { newValue in Async(value: transform(newValue)) }
   }
 }
 

--- a/Sources/SnapshotTesting/Snapshotting.swift
+++ b/Sources/SnapshotTesting/Snapshotting.swift
@@ -46,32 +46,34 @@ public struct Snapshotting<Value, Format> {
     }
   }
 
-  /// Transforms a strategy on `Value`s into a strategy on `Root`s through a function `(Root) -> Async<Value>`.
+  /// Transforms a strategy on `Value`s into a strategy on `NewValue`s through a function `(NewValue) -> Async<Value>`.
   ///
   /// - Parameters:
-  ///   - transform: A transform function from `Root` into `Async<Value>`.
+  ///   - transform: A transform function from `NewValue` into `Async<Value>`.
   ///   - otherValue: A value to be transformed.
-  public func asyncPullback<Root>(_ transform: @escaping (_ otherValue: Root) -> Async<Value>) -> Snapshotting<Root, Format> {
-    return Snapshotting<Root, Format>(
-      pathExtension: self.pathExtension,
-      diffing: self.diffing
-    ) { root in
-      return .init { callback in
-        transform(root).run { value in
-          self.snapshot(value).run { snapshot in
-            callback(snapshot)
+  public func asyncPullback<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Async<Value>)
+    -> Snapshotting<NewValue, Format> {
+
+      return Snapshotting<NewValue, Format>(
+        pathExtension: self.pathExtension,
+        diffing: self.diffing
+      ) { newValue in
+        return .init { callback in
+          transform(newValue).run { value in
+            self.snapshot(value).run { snapshot in
+              callback(snapshot)
+            }
           }
         }
       }
-    }
   }
 
-  /// Transforms a strategy on `Value`s into a strategy on `A`s through a function `(A) -> Value`.
+  /// Transforms a strategy on `Value`s into a strategy on `NewValue`s through a function `(NewValue) -> Value`.
   ///
   /// - Parameters:
-  ///   - transform: A transform function from `A` into `Value`.
+  ///   - transform: A transform function from `NewValue` into `Value`.
   ///   - otherValue: A value to be transformed.
-  public func pullback<Root>(_ transform: @escaping (_ otherValue: Root) -> Value) -> Snapshotting<Root, Format> {
+  public func pullback<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Value) -> Snapshotting<NewValue, Format> {
     return self.asyncPullback { root in Async(value: transform(root)) }
   }
 }


### PR DESCRIPTION
The `A` can make the pullback concept a lil harder to understand, I think. How about we ground it in a more familiar concept by calling it `Root`? It's not quite the same as `Root`-`Value` of key paths, but it's a similar relationship.