### PR TITLE
Make XCTAttachment's initializers public

### DIFF
--- a/Sources/SnapshotTesting/Common/XCTAttachment.swift
+++ b/Sources/SnapshotTesting/Common/XCTAttachment.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct XCTAttachment {
-  init(data: Data) {}
-  init(data: Data, uniformTypeIdentifier: String) {}
+  public init(data: Data) {}
+  public init(data: Data, uniformTypeIdentifier: String) {}
 }
 #endif


### PR DESCRIPTION
I wanted to add a new `Diffing` strategy. `Diffing` needs to be initialized with a closure of type `(Value, Value) -> (String, [XCTAttachment])?`.

On macOS a can create an `XCTAttachment`, but that doesn't work on Linux since the initializers of `XCTAttachment` are internal. This is fixed here.