### PR TITLE
Add option to provide own reference directory for images

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -141,8 +141,10 @@ public func verifySnapshot<Value, Format>(
     do {
       let fileUrl = URL(fileURLWithPath: "\(file)")
       let fileName = fileUrl.deletingPathExtension().lastPathComponent
-      let directoryUrl = fileUrl.deletingLastPathComponent()
-      let snapshotDirectoryUrl: URL = directoryUrl
+      let userDefinedDirectory = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]
+      let fallbackDirectoryUrl = fileUrl.deletingLastPathComponent()
+      let snapshotDirectoryBaseUrl = userDefinedDirectory.flatMap(URL.init(fileURLWithPath:)) ?? fallbackDirectoryUrl
+      let snapshotDirectoryUrl: URL = snapshotDirectoryBaseUrl
         .appendingPathComponent("__Snapshots__")
         .appendingPathComponent(fileName)
 

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -143,8 +143,10 @@ open class SnapshotTestCase: XCTestCase {
       do {
         let fileUrl = URL(fileURLWithPath: "\(file)")
         let fileName = fileUrl.deletingPathExtension().lastPathComponent
-        let directoryUrl = fileUrl.deletingLastPathComponent()
-        let snapshotDirectoryUrl: URL = directoryUrl
+        let userDefinedDirectory = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]
+        let fallbackDirectoryUrl = fileUrl.deletingLastPathComponent()
+        let snapshotDirectoryBaseUrl = userDefinedDirectory.flatMap(URL.init(fileURLWithPath:)) ?? fallbackDirectoryUrl
+        let snapshotDirectoryUrl: URL = snapshotDirectoryBaseUrl
           .appendingPathComponent("__Snapshots__")
           .appendingPathComponent(fileName)
 


### PR DESCRIPTION
Hey guys! 

First of all thanks for this awesome library, had used Jest for a while and this was something I wished iOS world had as well.

I was migrating from some other snapshot library and we were missing one environment variable that we were using - custom directory for recorded snapshots.

I named it `SNAPSHOT_REFERENCE_DIR`, but let me know if you think there is a more suitable name for this one.

<img width="598" alt="zrzut ekranu 2019-01-31 o 14 04 55" src="https://user-images.githubusercontent.com/5232779/52059199-736fa080-2569-11e9-9ffc-3e848deabd93.png">
