### PR TITLE
Create a typealias for SnapshotTestCase when not on Linux

### DIFF
--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 #if !os(Linux)
-@available(swift, obsoleted: 5.0, message: "Please use XCTestCase instead")
+@available(swift, obsoleted: 5.0, renamed: "XCTestCase", message: "Please use XCTestCase instead")
 public typealias SnapshotTestCase = XCTestCase
 #else
 

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 #if !os(Linux)
+@available(swift, obsoleted: 5.0, message: "Please use XCTestCase instead")
 public typealias SnapshotTestCase = XCTestCase
 #else
 

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -1,5 +1,8 @@
-#if os(Linux)
 import XCTest
+
+#if !os(Linux)
+public typealias SnapshotTestCase = XCTestCase
+#else
 
 /// An XCTest subclass that provides snaphot testing helpers.
 open class SnapshotTestCase: XCTestCase {

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -9,13 +9,7 @@ import SpriteKit
 import WebKit
 #endif
 
-#if os(Linux)
-typealias TestCase = SnapshotTestCase
-#else
-typealias TestCase = XCTestCase
-#endif
-
-class SnapshotTestingTests: TestCase {
+final class SnapshotTestingTests: SnapshotTestCase {
   override func setUp() {
     super.setUp()
     diffTool = "ksdiff"


### PR DESCRIPTION
Hey 👋 
Thank you for this library, is really cool and easy to use :)
While i was implementing some tests on a project that is both `macOS` and `Linux`, I came to a point where i had to create a `typealias` in order to make the tests work on both the platforms without have to duplicate the code (and i saw you did the same on your tests).
This is why i though that adding a public `typealias` would probably solve the problem for everyone that is using the library :)