### PR TITLE
Specify custom snapshot directory

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -38,8 +38,7 @@ public func assertSnapshot<Value, Format>(
     record: recording,
     timeout: timeout,
     file: file,
-    testName: testName,
-    line: line
+    testName: testName
   )
   guard let message = failure else { return }
   XCTFail(message, file: file, line: line)
@@ -114,11 +113,40 @@ public func assertSnapshots<Value, Format>(
 
 /// Verifies that a given value matches a reference on disk.
 ///
+/// Third party snapshot assert helpers can be built on top of this function. Simply invoke `verifySnapshot` with your own arguments, and then invoke `XCTFail` with the string returned if it is non-`nil`. For example, if you want the snapshot directory to be determined by an environment variable, you can create your own assert helper like so:
+///
+///     public func myAssertSnapshot<Value, Format>(
+///       matching value: @autoclosure () throws -> Value,
+///       as snapshotting: Snapshotting<Value, Format>,
+///       named name: String? = nil,
+///       record recording: Bool = false,
+///       timeout: TimeInterval = 5,
+///       file: StaticString = #file,
+///       testName: String = #function,
+///       line: UInt = #line
+///       ) {
+///
+///         let snapshotDirectory = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]! + "/" + #file
+///         let failure = verifySnapshot(
+///           matching: value,
+///           as: snapshotting,
+///           named: name,
+///           record: recording,
+///           snapshotDirectory: snapshotDirectory,
+///           timeout: timeout,
+///           file: file,
+///           testName: testName
+///         )
+///         guard let message = failure else { return }
+///         XCTFail(message, file: file, line: line)
+///     }
+///
 /// - Parameters:
 ///   - value: A value to compare against a reference.
 ///   - snapshotting: A strategy for serializing, deserializing, and comparing values.
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
+///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
@@ -129,11 +157,10 @@ public func verifySnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool = false,
-  timeout: TimeInterval = 5,
   snapshotDirectory: String? = nil,
+  timeout: TimeInterval = 5,
   file: StaticString = #file,
-  testName: String = #function,
-  line: UInt = #line
+  testName: String = #function
   )
   -> String? {
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -130,6 +130,7 @@ public func verifySnapshot<Value, Format>(
   named name: String? = nil,
   record recording: Bool = false,
   timeout: TimeInterval = 5,
+  snapshotDirectory: String? = nil,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
@@ -141,10 +142,12 @@ public func verifySnapshot<Value, Format>(
     do {
       let fileUrl = URL(fileURLWithPath: "\(file)")
       let fileName = fileUrl.deletingPathExtension().lastPathComponent
-      let directoryUrl = fileUrl.deletingLastPathComponent()
-      let snapshotDirectoryUrl: URL = directoryUrl
-        .appendingPathComponent("__Snapshots__")
-        .appendingPathComponent(fileName)
+
+      let snapshotDirectoryUrl = snapshotDirectory.map(URL.init(fileURLWithPath:))
+        ?? fileUrl
+          .deletingLastPathComponent()
+          .appendingPathComponent("__Snapshots__")
+          .appendingPathComponent(fileName)
 
       let identifier: String
       if let name = name {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -38,7 +38,8 @@ public func assertSnapshot<Value, Format>(
     record: recording,
     timeout: timeout,
     file: file,
-    testName: testName
+    testName: testName,
+    line: line
   )
   guard let message = failure else { return }
   XCTFail(message, file: file, line: line)
@@ -160,7 +161,8 @@ public func verifySnapshot<Value, Format>(
   snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
   file: StaticString = #file,
-  testName: String = #function
+  testName: String = #function,
+  line: UInt = #line
   )
   -> String? {
 

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -135,6 +135,7 @@ open class SnapshotTestCase: XCTestCase {
     as snapshotting: Snapshotting<Value, Format>,
     named name: String? = nil,
     record recording: Bool = false,
+    snapshotDirectory: String? = nil,
     timeout: TimeInterval = 5,
     file: StaticString = #file,
     testName: String = #function,
@@ -147,10 +148,12 @@ open class SnapshotTestCase: XCTestCase {
       do {
         let fileUrl = URL(fileURLWithPath: "\(file)")
         let fileName = fileUrl.deletingPathExtension().lastPathComponent
-        let directoryUrl = fileUrl.deletingLastPathComponent()
-        let snapshotDirectoryUrl: URL = directoryUrl
-          .appendingPathComponent("__Snapshots__")
-          .appendingPathComponent(fileName)
+
+        let snapshotDirectoryUrl = snapshotDirectory.map(URL.init(fileURLWithPath:))
+          ?? fileUrl
+            .deletingLastPathComponent()
+            .appendingPathComponent("__Snapshots__")
+            .appendingPathComponent(fileName)
 
         let identifier: String
         if let name = name {

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -44,8 +44,7 @@ open class SnapshotTestCase: XCTestCase {
       record: recording,
       timeout: timeout,
       file: file,
-      testName: testName,
-      line: line
+      testName: testName
     )
     guard let message = failure else { return }
     XCTFail(message, file: file, line: line)
@@ -138,8 +137,7 @@ open class SnapshotTestCase: XCTestCase {
     snapshotDirectory: String? = nil,
     timeout: TimeInterval = 5,
     file: StaticString = #file,
-    testName: String = #function,
-    line: UInt = #line
+    testName: String = #function
     )
     -> String? {
 

--- a/Sources/SnapshotTesting/SnapshotTestCase.swift
+++ b/Sources/SnapshotTesting/SnapshotTestCase.swift
@@ -44,7 +44,8 @@ open class SnapshotTestCase: XCTestCase {
       record: recording,
       timeout: timeout,
       file: file,
-      testName: testName
+      testName: testName,
+      line: line
     )
     guard let message = failure else { return }
     XCTFail(message, file: file, line: line)
@@ -137,7 +138,8 @@ open class SnapshotTestCase: XCTestCase {
     snapshotDirectory: String? = nil,
     timeout: TimeInterval = 5,
     file: StaticString = #file,
-    testName: String = #function
+    testName: String = #function,
+    line: UInt = #line
     )
     -> String? {
 


### PR DESCRIPTION
This addresses the issue brought up in: https://github.com/pointfreeco/swift-snapshot-testing/pull/167

The `verifySnapshot` helper will now take an optional snapshot directory that will override the default behavior of using `/{testDirectory}/__Snapshots__/{testFileName}`.