### PR TITLE
Proof of concept - Informing

### DIFF
--- a/SnapshotTesting.xcodeproj/project.pbxproj
+++ b/SnapshotTesting.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		33470EBE2233E99F002EC0A2 /* Informing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33470EBD2233E99F002EC0A2 /* Informing.swift */; };
+		33470EBF2233E99F002EC0A2 /* Informing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33470EBD2233E99F002EC0A2 /* Informing.swift */; };
+		33470EC02233E99F002EC0A2 /* Informing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33470EBD2233E99F002EC0A2 /* Informing.swift */; };
 		BF_04E4225C7AC81D2E93C9A210AD1C768C /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_5ABFA0C568E5F812C96A9872ED576BDA /* Description.swift */; };
 		BF_056DF95B208610B26A04CB328545B236 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_750D6728D7492B7DD301DAED19ABD98F /* CALayer.swift */; };
 		BF_05C3161CF564303E9D4AC30321A44C35 /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FR_DA4183393C1DF1FE2E01DCB0D845772C /* UIImage.swift */; };
@@ -160,6 +163,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		33470EBD2233E99F002EC0A2 /* Informing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Informing.swift; sourceTree = "<group>"; };
 		FR_005396B25C1F9DA46556618A49C9C47B /* NSImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImage.swift; sourceTree = "<group>"; };
 		FR_1C0F0F9D1E3946C22AB189D75CBFA00A /* SnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FR_249284F48787C8FEC6C4C3B317A68737 /* SnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -258,6 +262,7 @@
 				FR_4B671595EC397E2142ED555D6EA3B5C5 /* Snapshotting.swift */,
 				G_BA5C1E83965C514CC7D95706C68E181E /* Common */,
 				G_F0974E282B3FC447C9E6CC190D1AC2CE /* Snapshotting */,
+				33470EBD2233E99F002EC0A2 /* Informing.swift */,
 			);
 			path = SnapshotTesting;
 			sourceTree = "<group>";
@@ -464,6 +469,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF_62AD99C1B3A8484024522ACBB7508934 /* Any.swift in Sources */,
+				33470EBE2233E99F002EC0A2 /* Informing.swift in Sources */,
 				BF_60E780A5566C14D1B9C49FE1213C005F /* AssertSnapshot.swift in Sources */,
 				BF_1092D6738E4E10DA749423711942C04C /* Async.swift in Sources */,
 				BF_B3BE9EA2F5E7F5B4AC137BB9BD46F6BF /* CALayer.swift in Sources */,
@@ -497,6 +503,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF_C3DA65F8B72D393D5E907074465BDFD1 /* Any.swift in Sources */,
+				33470EBF2233E99F002EC0A2 /* Informing.swift in Sources */,
 				BF_CEA78BD0477B1745D042FAE6049A5B73 /* AssertSnapshot.swift in Sources */,
 				BF_97AA84D478C020B4F7906D46DA4D0C15 /* Async.swift in Sources */,
 				BF_056DF95B208610B26A04CB328545B236 /* CALayer.swift in Sources */,
@@ -530,6 +537,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BF_803219DA32D805A2734E66442011B2B3 /* Any.swift in Sources */,
+				33470EC02233E99F002EC0A2 /* Informing.swift in Sources */,
 				BF_F896D52B8FF76B9328361A8857B4BF87 /* AssertSnapshot.swift in Sources */,
 				BF_51479BC7C87FC0B4B8FBFD68EEBD3726 /* Async.swift in Sources */,
 				BF_5BB83217C775F89CF3FDE1B31B347BE6 /* CALayer.swift in Sources */,
@@ -678,7 +686,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -701,7 +712,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -723,7 +737,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -838,7 +855,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -861,7 +881,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -910,7 +933,10 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Sources/SnapshotTesting/Informing.swift
+++ b/Sources/SnapshotTesting/Informing.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The ability to generate user messages for recorded snapshots and failed tests
+public struct Informing<Format> {
+  public let snapshotRecorded: (_ testName: String, _ snapshotFileUrl: URL) -> String
+  public let testFailed: (_ testName: String, _ snapshotFileUrl: URL, _ failedSnapshotFileUrl: URL) -> String
+
+  /// Creates a new `Informing`
+  ///
+  /// - Parameters:
+  ///   - snapshotRecorded: A function used to generate a message for a new snapshot recording
+  ///   - testName: Name of the test for which the snapshot was recorded
+  ///   - snapshotFileUrl: Url to the snapshot file
+  ///   - testFailed: A function used to generate a message for a test failure
+  ///   - testName: Name of the test that failed
+  ///   - snapshotFileUrl: Url to the snapshot file
+  ///   - failedSnapshotFileUrl: Url to the failed snapshot file
+  public init(
+    snapshotRecorded: @escaping (_ testName: String, _ snapshotFileUrl: URL) -> String,
+    testFailed: @escaping (_ testName: String, _ snapshotFileUrl: URL, _ failedSnapshotFileUrl: URL) -> String
+    ) {
+    self.snapshotRecorded = snapshotRecorded
+    self.testFailed = testFailed
+  }
+}
+
+public extension Informing {
+  public static var basic: Informing {
+    return Informing(
+      snapshotRecorded: { (testName, snapshotFileUrl) -> String in
+        return "open \"\(snapshotFileUrl.path)\""
+      },
+      testFailed: { (testName, snapshotFileUrl, failedSnapshotFileUrl) -> String in
+        return "@\(minus)\n\"\(snapshotFileUrl.path)\"\n@\(plus)\n\"\(failedSnapshotFileUrl.path)\""
+      }
+    )
+  }
+  public static var ksdiff: Informing {
+    return Informing(
+      snapshotRecorded: Informing.basic.snapshotRecorded,
+      testFailed: { (testName, snapshotFileUrl, failedSnapshotFileUrl) -> String in
+        return "ksdiff \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\""
+      }
+    )
+  }
+}

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -12,7 +12,6 @@ import WebKit
 final class SnapshotTestingTests: SnapshotTestCase {
   override func setUp() {
     super.setUp()
-    diffTool = "ksdiff"
 //    record = true
   }
 
@@ -24,7 +23,7 @@ final class SnapshotTestingTests: SnapshotTestCase {
   func testAny() {
     struct User { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
-    assertSnapshot(matching: user, as: .dump)
+    assertSnapshot(matching: user, as: .dump, informing: .ksdiff)
   }
 
   func testAnySnapshotStringConvertible() {


### PR DESCRIPTION
👋  While working with SnapshotTesting and mostly comparing images doing iOS-on-mac, I realized that my workflow isn't where I would like it to be. I found myself moving the cursor around a lot to see the the attachements in Xcode, or selecting the commands to open a custom diff tool. I noticed it the most in 3 scenarios:

- 1. Running the test for the first time - The reference is automatically recorded 🔝 . I like to check the image myself before commiting my changes, so I copy-paste the path to see the image
- 2. Comparing a failing test - All images are attached in Xcode 💯 . Seeing the attachements requires some navigation around Xcode, or copying the produced command.
- 3. Recording a new reference - It's as simple as setting `record = true` and re-running the test. The "new" reference already exists after the first run in the form of the failing snapshot, so I thought to myself - why not just use it?

To address these, I started experimenting on a POC for a Mac app that I would run alongside Xcode. The app would "listen" for the failing tests, and it would display the reference and the failing snapshot in realtime. Changing the reference wouldn't require a record re-run. Here is a GIF of it in action:

![Viewer POC](https://user-images.githubusercontent.com/2226475/54072868-db0fbe80-4280-11e9-8a0a-f49c29b1d723.gif)


To get to the POC, I played around with a fork of SnapshotTesting in which I modified the parts that inform on reference recordings and test failures. I was wondering if such a similar change would be acceptable as part of the main repo.
In this PR, I added a concept of how that might look:

The `Informing` struct is the ability to inform the user (me, yay) about new reference recordings and failing tests. The functions return `String` so it's easy to plug in the existing code, and print them alongside the failure message.
It would "formalize" the `diffTool` a bit, and allow for more variety via plug-ins. Right now, we can only extend the `diffTool` by providing a string value that would get printed in the output. Plug-ins would be able to add custom code that would process new recordings or test failures.

The struct is a generic on `Format`, but it doesn't use the type infromation in it's functions. The generic restriction is there to allow plugins to be created on certain `Format`s only. For example, I might want to open Kaleidoscope on test failures when the format is `Image`. That plug-in would be defined on the `Image` format.

The default `Informing` uses the existing behavior - it prints out the paths to the files.
As an example, I added `ksdiff` as a plug-in, but it would need to be reverted to `diffTool` to be backwards compatible.

What do you think?


Thanks for the great library! 😍  SnapshotTesting and Witness Oriented Design!