### PR TITLE
Add link to swift-snapshot-testing-nimble

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ dependencies: [
 
 ## Plug-ins
 
+  - [swift-snapshot-testing-nimble](https://github.com/Killectro/swift-snapshot-testing-nimble) adds [Nimble](https://github.com/Quick/Nimble) matchers for SnapshotTesting.
+
   - [swift-html](https://github.com/pointfreeco/swift-html) is a Swift DSL for type-safe, extensible, and transformable HTML documents and includes an `HtmlSnapshotTesting` module to snapshot test its HTML documents.
 
 Have you written your own SnapshotTesting plug-in? [Add it here](https://github.com/pointfreeco/swift-snapshot-testing/edit/master/README.md) and submit a pull request!


### PR DESCRIPTION
Would be nice to link to @Killectro's plug-in in the README.