### PR TITLE
Enable users to add userInfo to failure attachments

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -149,6 +149,7 @@ public func assertSnapshots<Value, Format>(
 ///   - recording: Whether or not to record a new reference.
 ///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
 ///   - timeout: The amount of time a snapshot must be generated in.
+///   - attachmentUserInfo: A dictionary of information which is added to failure attachments.
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
@@ -160,6 +161,7 @@ public func verifySnapshot<Value, Format>(
   record recording: Bool = false,
   snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
+  attachmentUserInfo: [AnyHashable: Any]? = nil,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
@@ -260,8 +262,17 @@ public func verifySnapshot<Value, Format>(
         #if !os(Linux)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
           XCTContext.runActivity(named: "Attached Failure Diff") { activity in
-            attachments.forEach {
-              activity.add($0)
+            attachments.forEach { attachment in
+              if let userInfo = attachmentUserInfo {
+                if attachment.userInfo == nil {
+                  attachment.userInfo = [:]
+                }
+                userInfo.forEach { key, value in
+                  attachment.userInfo?[key] = value
+                }
+              }
+              
+              activity.add(attachment)
             }
           }
         }

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -20,9 +20,18 @@ extension Diffing where Value == NSImage {
       let message = new.size == old.size
         ? "Newly-taken snapshot does not match reference"
         : "Newly-taken snapshot@\(new.size) does not match match reference@\(old.size)"
+      let oldAttachment = XCTAttachment(image: old)
+      oldAttachment.name = "reference"
+      oldAttachment.lifetime = .keepAlways
+      let newAttachment = XCTAttachment(image: new)
+      newAttachment.name = "failure"
+      newAttachment.lifetime = .keepAlways
+      let differenceAttachment = XCTAttachment(image: difference)
+      differenceAttachment.name = "difference"
+      differenceAttachment.lifetime = .keepAlways
       return (
         message,
-        [XCTAttachment(image: old), XCTAttachment(image: new), XCTAttachment(image: difference)]
+        [oldAttachment, newAttachment, differenceAttachment]
       )
     }
   }

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -21,6 +21,7 @@ extension Diffing where Value == String {
       .flatMap { [$0.patchMark] + $0.lines }
       .joined(separator: "\n")
     let attachment = XCTAttachment(data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
+    attachment.lifetime = .keepAlways
     return (failure, [attachment])
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -22,10 +22,13 @@ extension Diffing where Value == UIImage {
         : "Newly-taken snapshot@\(new.size) does not match match reference@\(old.size)"
       let oldAttachment = XCTAttachment(image: old)
       oldAttachment.name = "reference"
+      oldAttachment.lifetime = .keepAlways
       let newAttachment = XCTAttachment(image: new)
       newAttachment.name = "failure"
+      newAttachment.lifetime = .keepAlways
       let differenceAttachment = XCTAttachment(image: difference)
       differenceAttachment.name = "difference"
+      differenceAttachment.lifetime = .keepAlways
       return (
         message,
         [oldAttachment, newAttachment, differenceAttachment]

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -571,6 +571,17 @@ final class SnapshotTestingTests: SnapshotTestCase {
     }
     #endif
   }
+  
+  func testAttachmentUserInfo() {
+    #if os(iOS) || os(macOS)
+    let result = verifySnapshot(matching: UUID().uuidString, as: .dump, userInfo: [
+      "stringKey": "value",
+      "numberKey": 1
+    ])
+    
+    XCTAssertNotNil(result)
+    #endif
+  }
 }
 
 #if os(Linux)

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testAttachmentUserInfo.1.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testAttachmentUserInfo.1.txt
@@ -1,0 +1,1 @@
+- "constant"


### PR DESCRIPTION
Hey 👋 

#### Justification:
I'm working on a separate tool for creating nicely formatted reports for our snapshot testing but we've hit a bit of a blocker when it came to handling the failure attachments which are available in the `TestSummaries.plist` file Xcode generates.

Essentially the file has an array of activities (depending on how many comparisons it does within one test), and inside each of them several attachments (depending on the diffing strategy) but there's no easy way to map an attachment back to the comparison it was running.

For instance we run our snapshot tests against 5 different devices. In this example, they all fail and we get 5 sets of 3 images. I would like the ability for my tool to then be able to show the 3 images under a header for which device they came from - this information is not currently available.

#### Solution:
With this merge request I've added an optional user info dictionary to the `verifySnapshot` method, this is then added to every failure attachment created for that run. This then let's our app store a small bit of information such as the device name alongside the attachment(s)

I've also expanded the macOS NSImage diffing to have titles for their attachments (much like iOS' UIImage) as well as ensuring that the attachments are kept even if the user does not fail their test (not mandatory with this library)

The test is designed to always fail (but the test will pass to prevent CI from locking up) - this enables us to validate the userInfo is stored within the log file. Unfortunately I couldn't find a way to validate the userInfo is actually stored automatically.