### PR TITLE
Sort headers in curl strategy.

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -52,8 +52,8 @@ extension Snapshotting where Value == URLRequest, Format == String {
 
     // Headers
     if let headers = request.allHTTPHeaderFields {
-      for (field, value) in headers where field != "Cookie" {
-        let escapedValue = value.replacingOccurrences(of: "\"", with: "\\\"")
+      for field in headers.keys.sorted() where field != "Cookie" {
+        let escapedValue = headers[field]!.replacingOccurrences(of: "\"", with: "\\\"")
         components.append("--header \"\(field): \(escapedValue)\"")
       }
     }

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -614,6 +614,7 @@ final class SnapshotTestingTests: XCTestCase {
     var get = URLRequest(url: URL(string: "https://www.pointfree.co/")!)
     get.addValue("pf_session={}", forHTTPHeaderField: "Cookie")
     get.addValue("text/html", forHTTPHeaderField: "Accept")
+    get.addValue("application/json", forHTTPHeaderField: "Content-Type")
     assertSnapshot(matching: get, as: .raw, named: "get")
     assertSnapshot(matching: get, as: .curl, named: "get-curl")
 

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-curl.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-curl.txt
@@ -1,4 +1,5 @@
 curl \
 	--header "Accept: text/html" \
+	--header "Content-Type: application/json" \
 	--cookie "pf_session={}" \
 	"https://www.pointfree.co/"

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get.txt
@@ -1,3 +1,4 @@
 GET https://www.pointfree.co/
 Accept: text/html
+Content-Type: application/json
 Cookie: pf_session={}


### PR DESCRIPTION
The curl strategy is currently useless for requests that have more than one header because they come out in a random order. This change sorts the headers and also introduces a second header (`Content-Type`) to one of the tests to help detect this going forward.

I'm open to any insights on making a consistently failing test. Adding more headers would increase the likeliness but not guarantee it.

Somewhat related, the curl strategy doesn't play nice with the new inline snapshotting feature due to the `\` characters not being escaped. I think some escaping should be done on the strings before inlining them into the file. For example try adding this test (it will fail with the auto-inlined string):

```swift
_assertInlineSnapshot(matching: get, as: .curl, with: """
curl \
  --header "Accept: text/html" \
  --header "Content-Type: application/json" \
  --cookie "pf_session={}" \
  "https://www.pointfree.co/"
""")
```