### PR TITLE
Add iOS minimum required deployment target to Swift PM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,9 @@ import PackageDescription
 
 let package = Package(
   name: "SnapshotTesting",
+  platforms: [
+    .iOS(.v10)
+  ],
   products: [
     .library(
       name: "SnapshotTesting",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,9 @@ import PackageDescription
 let package = Package(
   name: "SnapshotTesting",
   platforms: [
-    .iOS(.v10)
+    .iOS(.v10),
+    .macOS(.v10_10),
+    .tvOS(.v10)
   ],
   products: [
     .library(


### PR DESCRIPTION
This fixes an issue with using the Swift Package Manager `generate-xcodeproj` to build `swift-snapshot-testing` for iOS in Xcode 10.2!

Because `swift-snapshot-testing` uses APIs like UIGraphicsImageRenderer, it is only compatible with iOS 10 or later. As of Swift 5, if a [minimum required deployment target](https://github.com/apple/swift-evolution/blob/master/proposals/0236-package-manager-platform-deployment-settings.md) isn't provided for a platform, the "oldest deployment target version supported by the installed SDK" will be used. In the case of Xcode 10.2 that means iOS 8, so using `generate-xcodeproj` results in iOS 8 being set as the `IPHONEOS_DEPLOYMENT_TARGET`. This causes build errors due to usage of iOS 9/10+ APIs without #available attribute checks. You can test this pretty easily by running `swift package generate-xcodeproj` on the repo and then trying to build the framework in Xcode against the iOS simulator.