### PR TITLE
Disable bitcode for target xcconfig

### DIFF
--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -31,6 +31,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "10.0"
 
   s.frameworks = "XCTest"
+  s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }
 
   s.source_files  = "Sources", "Sources/**/*.swift"
 end


### PR DESCRIPTION
Fixing physical device-targeted build issue (no bitcode in XCTest). Similar to the change for Carthage: https://github.com/pointfreeco/swift-snapshot-testing/pull/104