### PR TITLE
Using URL.init(fileURLWithPath:isDirectory:)

### DIFF
--- a/Sources/SnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertInlineSnapshot.swift
@@ -105,7 +105,7 @@ public func _verifyInlineSnapshot<Value>(
       // If that diff failed, we either record or fail.
       if recording || trimmedReference.isEmpty {
         let fileName = "\(file)"
-        let sourceCodeFilePath = URL(fileURLWithPath: fileName)
+        let sourceCodeFilePath = URL(fileURLWithPath: fileName, isDirectory: false)
         var sourceCodeLines = try String(contentsOf: sourceCodeFilePath).split(separator: "\n", omittingEmptySubsequences: false)
         let lineIndex = Int(line)
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -168,10 +168,10 @@ public func verifySnapshot<Value, Format>(
     let recording = recording || record
 
     do {
-      let fileUrl = URL(fileURLWithPath: "\(file)")
+      let fileUrl = URL(fileURLWithPath: "\(file)", isDirectory: false)
       let fileName = fileUrl.deletingPathExtension().lastPathComponent
 
-      let snapshotDirectoryUrl = snapshotDirectory.map(URL.init(fileURLWithPath:))
+      let snapshotDirectoryUrl = snapshotDirectory.map { URL(fileURLWithPath: $0, isDirectory: true) }
         ?? fileUrl
           .deletingLastPathComponent()
           .appendingPathComponent("__Snapshots__")
@@ -250,7 +250,7 @@ public func verifySnapshot<Value, Format>(
       }
 
       let artifactsUrl = URL(
-        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory()
+        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
       try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -225,7 +225,7 @@ final class SnapshotTestingTests: XCTestCase {
       sphereNode.position = SCNVector3Zero
       scene.rootNode.addChildNode(sphereNode)
 
-      sphereGeometry.firstMaterial?.diffuse.contents = URL(fileURLWithPath: String(#file))
+      sphereGeometry.firstMaterial?.diffuse.contents = URL(fileURLWithPath: String(#file), isDirectory: false)
         .deletingLastPathComponent()
         .appendingPathComponent("__Fixtures__/earth.png")
 
@@ -661,7 +661,7 @@ final class SnapshotTestingTests: XCTestCase {
 
   func testWebView() throws {
     #if os(iOS) || os(macOS)
-    let fixtureUrl = URL(fileURLWithPath: String(#file))
+    let fixtureUrl = URL(fileURLWithPath: String(#file), isDirectory: false)
       .deletingLastPathComponent()
       .appendingPathComponent("__Fixtures__/pointfree.html")
     let html = try String(contentsOf: fixtureUrl)


### PR DESCRIPTION
Using init(fileURLWithPath:isDirectory:), which allows you to explicitly
specify whether the returned NSURL object represents a file or directory to avoid file system examination.

https://developer.apple.com/documentation/foundation/nsurl/1410301-init
Quote from the documentation:
"If path does not end with a slash, init(fileURLWithPath:) examines the file system to determine if path is a file or a directory."