### PR TITLE
Publicize assertInlineSnapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If your data can be represented as an image, text, or data, you can write a snap
 
 ## Snapshot Inline
 
-Text-based snapshots can be rendered inline in your test file. Write your snapshot test as you would otherwise, but replace the `assertSnapshot` function name with `assertInlineSnapshot`, and add the `with` parameter set to an empty string.
+Text-based snapshots can be rendered inline in your test file, making it particularly easy to verify a snapshot without loading it up elsewhere. Write your snapshot test as you would otherwise, but replace the `assertSnapshot` function name with `assertInlineSnapshot`, and add the `with` parameter set to an empty string.
 
 ``` swift
 assertInlineSnapshot(matching: user, as: .dump, with: """

--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ assertSnapshot(matching: user, as: .dump)
 
 If your data can be represented as an image, text, or data, you can write a snapshot test for it! Check out [all of the snapshot strategies](Documentation/Available-Snapshot-Strategies.md) that ship with SnapshotTesting and [learn how to define your own custom strategies](Documentation/Defining-Custom-Snapshot-Strategies.md).
 
+## Snapshot Inline
+
+Text-based snapshots can be rendered inline in your test file. Write your snapshot test as you would otherwise, but replace the `assertSnapshot` function name with `assertInlineSnapshot`, and add the `with` parameter set to an empty string.
+
+``` swift
+assertInlineSnapshot(matching: user, as: .dump, with: """
+""")
+```
+
+When you next run this test, it will fail, and a snapshot will be inserted inline:
+
+``` swift
+assertInlineSnapshot(matching: user, as: .dump, with: """
+▿ User
+  - bio: "Blobbed around the world."
+  - id: 1
+  - name: "Blobby"
+""")
+```
+
 ## Installation
 
 ### Carthage
@@ -131,7 +151,7 @@ If your data can be represented as an image, text, or data, you can write a snap
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:
 
 ``` ruby
-github "pointfreeco/swift-snapshot-testing" ~> 1.5
+github "pointfreeco/swift-snapshot-testing" ~> 1.6
 ```
 
 > ⚠️ Warning: Carthage instructs you to drag frameworks into your Xcode project. Xcode may automatically attempt to link these frameworks to your app target. `SnapshotTesting.framework` is only compatible with test targets, so when you first add it to your project:
@@ -149,7 +169,7 @@ If your project uses [CocoaPods](https://cocoapods.org), add the pod to any appl
 
 ```ruby
 target 'MyAppTests' do
-  pod 'SnapshotTesting', '~> 1.5'
+  pod 'SnapshotTesting', '~> 1.6'
 end
 ```
 
@@ -159,7 +179,7 @@ If you want to use SnapshotTesting in a project that uses [SwiftPM](https://swif
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.5.0"),
+  .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.6.0"),
 ]
 ```
 

--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "SnapshotTesting"
-  s.version = "1.5.0"
+  s.version = "1.6.0"
   s.summary = "Tests that save and assert against reference data"
 
   s.description = <<-DESC

--- a/Sources/SnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertInlineSnapshot.swift
@@ -194,7 +194,7 @@ public func _verifyInlineSnapshot<Value>(
   testName: String = #function,
   line: UInt = #line
 ) -> String? {
-  verifyInlineSnapshot(
+  return verifyInlineSnapshot(
     matching: try value(),
     as: snapshotting,
     record: recording,

--- a/Tests/SnapshotTestingTests/InlineSnapshotTests.swift
+++ b/Tests/SnapshotTestingTests/InlineSnapshotTests.swift
@@ -2,11 +2,15 @@ import XCTest
 @testable import SnapshotTesting
 
 class InlineSnapshotTests: XCTestCase {
+  override func setUp() {
+    super.setUp()
+//    record = true
+  }
 
   func testCreateSnapshotSingleLine() {
     let diffable = "NEW_SNAPSHOT"
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: "")
+    assertInlineSnapshot(matching: diffable, as: .lines, with: "")
     """
 
     var recordings: Recordings = [:]
@@ -21,7 +25,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotMultiLine() {
     let diffable = "NEW_SNAPSHOT"
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     """)
     """#
 
@@ -37,7 +41,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshot() {
     let diffable = "NEW_SNAPSHOT"
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     OLD_SNAPSHOT
     """)
     """#
@@ -54,7 +58,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithMoreLines() {
     let diffable = "NEW_SNAPSHOT\nNEW_SNAPSHOT"
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     OLD_SNAPSHOT
     """)
     """#
@@ -71,7 +75,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithLessLines() {
     let diffable = "NEW_SNAPSHOT"
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     OLD_SNAPSHOT
     OLD_SNAPSHOT
     """)
@@ -89,7 +93,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithExtendedDelimiterSingleLine1() {
     let diffable = #"\""#
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: "")
+    assertInlineSnapshot(matching: diffable, as: .lines, with: "")
     """
 
     var recordings: Recordings = [:]
@@ -107,7 +111,7 @@ class InlineSnapshotTests: XCTestCase {
     cde \
     """#
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: "")
+    assertInlineSnapshot(matching: diffable, as: .lines, with: "")
     """
 
     var recordings: Recordings = [:]
@@ -122,7 +126,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithExtendedDelimiterSingleLine2() {
     let diffable = ##"\"""#"##
     let source = ##"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: "")
+    assertInlineSnapshot(matching: diffable, as: .lines, with: "")
     """##
 
     var recordings: Recordings = [:]
@@ -137,7 +141,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithExtendedDelimiter1() {
     let diffable = #"\""#
     let source = ##"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     """#)
     """##
 
@@ -153,7 +157,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ###"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     """##)
     """###
 
@@ -169,7 +173,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithLongerExtendedDelimiter1() {
     let diffable =  #"\""#
     let source = ###"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     """##)
     """###
 
@@ -185,7 +189,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithLongerExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ####"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ###"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ###"""
     """###)
     """####
 
@@ -201,7 +205,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithShorterExtendedDelimiter1() {
     let diffable = #"\""#
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     """)
     """#
 
@@ -217,7 +221,7 @@ class InlineSnapshotTests: XCTestCase {
   func testCreateSnapshotWithShorterExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ##"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     """#)
     """##
 
@@ -233,7 +237,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithExtendedDelimiter1() {
     let diffable = #"\""#
     let source = ##"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
     """##
@@ -250,7 +254,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ###"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     "#
     """##)
     """###
@@ -267,7 +271,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithLongerExtendedDelimiter1() {
     let diffable = #"\""#
     let source = #"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     \"
     """)
     """#
@@ -284,7 +288,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithLongerExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ##"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     "#
     """#)
     """##
@@ -301,7 +305,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithShorterExtendedDelimiter1() {
     let diffable = #"\""#
     let source = ###"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"
     """##)
     """###
@@ -318,7 +322,7 @@ class InlineSnapshotTests: XCTestCase {
   func testUpdateSnapshotWithShorterExtendedDelimiter2() {
     let diffable = ##"\"""#"##
     let source = ####"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ###"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ###"""
     "#
     """###)
     """####
@@ -341,11 +345,11 @@ class InlineSnapshotTests: XCTestCase {
     let diffable2 = "NEW_SNAPSHOT"
 
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
     OLD_SNAPSHOT
     \""")
 
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
     OLD_SNAPSHOT
     \""")
     """
@@ -372,12 +376,12 @@ class InlineSnapshotTests: XCTestCase {
     let diffable2 = "NEW_SNAPSHOT"
 
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
     OLD_SNAPSHOT
     with two lines
     \""")
 
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
     OLD_SNAPSHOT
     \""")
     """
@@ -407,11 +411,11 @@ class InlineSnapshotTests: XCTestCase {
     """
 
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
     OLD_SNAPSHOT
     \""")
 
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
     OLD_SNAPSHOT
     with two lines
     \""")
@@ -442,12 +446,12 @@ class InlineSnapshotTests: XCTestCase {
     """
 
     let source = """
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: \"""
     OLD_SNAPSHOT
     with two lines
     \""")
 
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: \"""
     OLD_SNAPSHOT
     \""")
     """
@@ -475,7 +479,7 @@ class InlineSnapshotTests: XCTestCase {
     """##
 
     let source = ######"""
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #####"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #####"""
     """#####)
     """######
 
@@ -540,11 +544,8 @@ extension Snapshotting where Value == String, Format == String {
   }
 }
 
-// Class that is extended with the generated code to check that it builds.
-// Besides that, the generated code is a test itself, which tests that the
-// snapshotted value is equal to the original value.
-// With this test we check that we escaped correctly
-// e.g. if we enclose \" in """ """ instead of #""" """#,
-// the character sequence will be interpreted as " instead of \"
-// The generated tests check this issues.
+// Class that is extended with the generated code to check that it builds. Besides that, the generated code
+// is a test itself, which tests that the snapshot is equal to the original value. With this test we check
+// that we escaped correctly, _e.g._, if we enclose \" in """ """ instead of #""" """#, the character
+// sequence will be interpreted as " instead of \". The generated tests check this issues.
 class InlineSnapshotsValidityTests: XCTestCase {}

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -25,7 +25,7 @@ final class SnapshotTestingTests: XCTestCase {
     struct User { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
     assertSnapshot(matching: user, as: .dump)
-    _assertInlineSnapshot(matching: user, as: .dump, with: """
+    assertInlineSnapshot(matching: user, as: .dump, with: """
     ▿ User
       - bio: "Blobbed around the world."
       - id: 1
@@ -42,25 +42,25 @@ final class SnapshotTestingTests: XCTestCase {
     assertSnapshot(matching: "Hello, world!".dropLast(8), as: .dump, named: "substring")
     assertSnapshot(matching: URL(string: "https://www.pointfree.co")!, as: .dump, named: "url")
     // Inline
-    _assertInlineSnapshot(matching: "a" as Character, as: .dump, with: """
+    assertInlineSnapshot(matching: "a" as Character, as: .dump, with: """
     - "a"
     """)
-    _assertInlineSnapshot(matching: Data("Hello, world!".utf8), as: .dump, with: """
+    assertInlineSnapshot(matching: Data("Hello, world!".utf8), as: .dump, with: """
     - 13 bytes
     """)
-    _assertInlineSnapshot(matching: Date(timeIntervalSinceReferenceDate: 0), as: .dump, with: """
+    assertInlineSnapshot(matching: Date(timeIntervalSinceReferenceDate: 0), as: .dump, with: """
     - 2001-01-01T00:00:00Z
     """)
-    _assertInlineSnapshot(matching: NSObject(), as: .dump, with: """
+    assertInlineSnapshot(matching: NSObject(), as: .dump, with: """
     - <NSObject>
     """)
-    _assertInlineSnapshot(matching: "Hello, world!", as: .dump, with: """
+    assertInlineSnapshot(matching: "Hello, world!", as: .dump, with: """
     - "Hello, world!"
     """)
-    _assertInlineSnapshot(matching: "Hello, world!".dropLast(8), as: .dump, with: """
+    assertInlineSnapshot(matching: "Hello, world!".dropLast(8), as: .dump, with: """
     - "Hello"
     """)
-    _assertInlineSnapshot(matching: URL(string: "https://www.pointfree.co")!, as: .dump, with: """
+    assertInlineSnapshot(matching: URL(string: "https://www.pointfree.co")!, as: .dump, with: """
     - https://www.pointfree.co
     """)
   }
@@ -90,7 +90,7 @@ final class SnapshotTestingTests: XCTestCase {
       set: [.init(name: "Brandon"), .init(name: "Stephen")]
     )
     assertSnapshot(matching: set, as: .dump)
-    _assertInlineSnapshot(matching: set, as: .dump, with: """
+    assertInlineSnapshot(matching: set, as: .dump, with: """
     ▿ DictionarySetContainer
       ▿ dict: 3 key/value pairs
         ▿ (2 elements)
@@ -645,7 +645,7 @@ final class SnapshotTestingTests: XCTestCase {
     post.httpBody = Data("""
                          {"pricing": {"lane": "individual","billing": "monthly"}}
                          """.utf8)
-    _assertInlineSnapshot(matching: post, as: .raw(pretty: true), with: """
+    assertInlineSnapshot(matching: post, as: .raw(pretty: true), with: """
     POST https://www.pointfree.co/subscribe
     Accept: application/json
     Cookie: pf_session={"user_id":"0"}

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotEscapedNewlineLastLine.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotEscapedNewlineLastLine.1.swift
@@ -7,7 +7,7 @@ extension InlineSnapshotsValidityTests {
     cde \
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     abc \
     cde \
     """#)

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotMultiLine.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotMultiLine.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotSingleLine.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotSingleLine.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiterSingleLine1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiterSingleLine1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithLongerExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithLongerExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithLongerExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithLongerExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithShorterExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithShorterExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithShorterExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testCreateSnapshotWithShorterExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsSwapingLines1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsSwapingLines1.1.swift
@@ -11,11 +11,11 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     with two lines
     """)
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: """
     NEW_SNAPSHOT
     """)
    }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsSwapingLines2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsSwapingLines2.1.swift
@@ -11,10 +11,10 @@ extension InlineSnapshotsValidityTests {
     with two lines
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: """
     NEW_SNAPSHOT
     with two lines
     """)

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsWithLessLines.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsWithLessLines.1.swift
@@ -10,10 +10,10 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: """
     NEW_SNAPSHOT
     """)
    }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsWithMoreLines.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSeveralSnapshotsWithMoreLines.1.swift
@@ -11,11 +11,11 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     with two lines
     """)
-    _assertInlineSnapshot(matching: diffable2, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable2, as: .lines, with: """
     NEW_SNAPSHOT
     """)
    }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshot.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshot.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotCombined1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotCombined1.1.swift
@@ -9,7 +9,7 @@ extension InlineSnapshotsValidityTests {
       - name: "Bl#\"\"#obby"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     ▿ User
       - bio: "Blobbed around the world."
       - id: 1

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLessLines.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLessLines.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     """)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLongerExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLongerExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLongerExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithLongerExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithMoreLines.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithMoreLines.1.swift
@@ -7,7 +7,7 @@ extension InlineSnapshotsValidityTests {
     NEW_SNAPSHOT
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: """
+    assertInlineSnapshot(matching: diffable, as: .lines, with: """
     NEW_SNAPSHOT
     NEW_SNAPSHOT
     """)

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: #"""
     \"
     """#)
   }

--- a/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift
+++ b/Tests/SnapshotTestingTests/__Snapshots__/InlineSnapshotTests/testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift
@@ -6,7 +6,7 @@ extension InlineSnapshotsValidityTests {
     \"""#
     """#######
 
-    _assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
+    assertInlineSnapshot(matching: diffable, as: .lines, with: ##"""
     \"""#
     """##)
   }


### PR DESCRIPTION
The one caveat we've found to this API is that it breaks undo. I think we consider the advantages far outweigh this negative, though, and hopefully Xcode will get better undo support for writes that happen outside of Xcode in the future!