### PR TITLE
Use the same bytesPerRow value in contexts to speed up image diffing

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -61,8 +61,9 @@ private func compare(_ old: UIImage, _ new: UIImage, precision: Float) -> Bool {
   guard newCgImage.height != 0 else { return false }
   guard oldCgImage.height == newCgImage.height else { return false }
   // Values between images may differ due to padding to multiple of 64 bytes per row,
-  // e.g. freshly taken view snapshot may differ from one stored as PNG.
-  // At this point we're sure that size of both images is the same, so we can go with minimal `bytesPerRow` value.
+  // because of that a freshly taken view snapshot may differ from one stored as PNG.
+  // At this point we're sure that size of both images is the same, so we can go with minimal `bytesPerRow` value
+  // and use it to create contexts.
   let minBytesPerRow = min(oldCgImage.bytesPerRow, newCgImage.bytesPerRow)
   let byteCount = minBytesPerRow * oldCgImage.height
 

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -60,18 +60,22 @@ private func compare(_ old: UIImage, _ new: UIImage, precision: Float) -> Bool {
   guard oldCgImage.height != 0 else { return false }
   guard newCgImage.height != 0 else { return false }
   guard oldCgImage.height == newCgImage.height else { return false }
-  let maxBytesPerRow = max(oldCgImage.bytesPerRow, newCgImage.bytesPerRow)
-  let byteCount = maxBytesPerRow * oldCgImage.height
+  // Values between images may differ due to padding to multiple of 64 bytes per row,
+  // e.g. freshly taken view snapshot may differ from one stored as PNG.
+  // At this point we're sure that size of both images is the same, so we can go with minimal `bytesPerRow` value.
+  let minBytesPerRow = min(oldCgImage.bytesPerRow, newCgImage.bytesPerRow)
+  let byteCount = minBytesPerRow * oldCgImage.height
+
   var oldBytes = [UInt8](repeating: 0, count: byteCount)
-  guard let oldContext = context(for: oldCgImage, data: &oldBytes) else { return false }
+  guard let oldContext = context(for: oldCgImage, bytesPerRow: minBytesPerRow, data: &oldBytes) else { return false }
   guard let oldData = oldContext.data else { return false }
-  if let newContext = context(for: newCgImage), let newData = newContext.data {
+  if let newContext = context(for: newCgImage, bytesPerRow: minBytesPerRow), let newData = newContext.data {
     if memcmp(oldData, newData, byteCount) == 0 { return true }
   }
   let newer = UIImage(data: new.pngData()!)!
   guard let newerCgImage = newer.cgImage else { return false }
   var newerBytes = [UInt8](repeating: 0, count: byteCount)
-  guard let newerContext = context(for: newerCgImage, data: &newerBytes) else { return false }
+  guard let newerContext = context(for: newerCgImage, bytesPerRow: minBytesPerRow, data: &newerBytes) else { return false }
   guard let newerData = newerContext.data else { return false }
   if memcmp(oldData, newerData, byteCount) == 0 { return true }
   if precision >= 1 { return false }
@@ -84,7 +88,7 @@ private func compare(_ old: UIImage, _ new: UIImage, precision: Float) -> Bool {
   return true
 }
 
-private func context(for cgImage: CGImage, data: UnsafeMutableRawPointer? = nil) -> CGContext? {
+private func context(for cgImage: CGImage, bytesPerRow: Int, data: UnsafeMutableRawPointer? = nil) -> CGContext? {
   guard
     let space = cgImage.colorSpace,
     let context = CGContext(
@@ -92,7 +96,7 @@ private func context(for cgImage: CGImage, data: UnsafeMutableRawPointer? = nil)
       width: cgImage.width,
       height: cgImage.height,
       bitsPerComponent: cgImage.bitsPerComponent,
-      bytesPerRow: cgImage.bytesPerRow,
+      bytesPerRow: bytesPerRow,
       space: space,
       bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
     )


### PR DESCRIPTION
Hi!

At Babylon we have a lot of snapshot tests, so I looked into improving their performance. I managed to do so in three areas: image comparison, generating diff image (#249), and recording (#250).

This PR contains changes for image comparison. I'll open PRs for other changes separately as they are independent and I'm not sure whether you'd like to integrate all of them.

---

I profiled image comparison and the most expensive calls were drawing to context and converting to `pngData`. I noticed that [first `memcmp` check](https://github.com/pointfreeco/swift-snapshot-testing/blob/master/Sources/SnapshotTesting/Snapshotting/UIImage.swift#L69) usually fails for me. I looked at similar code in FB/Uber library and noticed that it's [using minimum value](https://github.com/uber/ios-snapshot-test-case/blame/b168a2f1e278b42422ed5ff5fb79b44b0f1f5c4c/FBSnapshotTestCase/Categories/UIImage+Compare.m#L54-L55) of `bytesPerRow` instead of maximum and later uses it to create contexts for both images. I dug a little more to make sense of it - it turns out that, as some kind of optimization, images are sometimes padded to multiples of 64 bytes per row. It looks like this was the cause of that first `memcmp` failure, e.g. fresh snapshot had 3008 `bytesPerRow` while the one stored in the PNG only 3000. Once the minimal value was taken into consideration and used in all contexts setup, the tests still passed and sped up. Thanks to this change the first `memcmp` check is often enough - [`new.pngData()`](https://github.com/pointfreeco/swift-snapshot-testing/blob/master/Sources/SnapshotTesting/Snapshotting/UIImage.swift#L71) is never reached and there's no draw to [`newerContext`](https://github.com/pointfreeco/swift-snapshot-testing/blob/master/Sources/SnapshotTesting/Snapshotting/UIImage.swift#L74). 

To get some real world data I did measurements on our UI framework snapshot tests. Results in seconds.

| Scenario | Run 1  | Run 2  | Run 3  | Run 4  | Run 5  | Run 6  |  Min  | Max  | Average  |
|---|---|---|---|---|---|---|---|---|---|
| CGContexts with distinct `bytesPerRow`  | 59,778  |  58,992 |  58,676 | 58,658  | 58,604  | 58,562  | 58,562  |  59,778 |  **58,878** | 
|CGContext with shared `bytesPerRow`  | 38,381  | 38,877  | 38,156  | 37,978  | 38,346  | 38,620  | 37,978  | 38,877  | **38,393**  |
<br/>

Now those tests take about **35% less time.**