### PR TITLE
Improve diff image drawing performance

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -16,7 +16,7 @@ extension Diffing where Value == UIImage {
       fromData: { UIImage(data: $0, scale: UIScreen.main.scale)! }
     ) { old, new in
       guard !compare(old, new, precision: precision) else { return nil }
-      let difference = SnapshotTesting.diff(old, new)
+//      let difference = SnapshotTesting.diff(old, new)
       let message = new.size == old.size
         ? "Newly-taken snapshot does not match reference."
         : "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
@@ -24,15 +24,15 @@ extension Diffing where Value == UIImage {
       oldAttachment.name = "reference"
       let newAttachment = XCTAttachment(image: new)
       newAttachment.name = "failure"
-      let differenceAttachment = XCTAttachment(image: difference)
-      differenceAttachment.name = "difference"
+//      let differenceAttachment = XCTAttachment(image: difference)
+//      differenceAttachment.name = "difference"
 
       let cgDifferenceAttachment = XCTAttachment(image: SnapshotTesting.cgDiff(old, new))
       cgDifferenceAttachment.name = "cg_difference"
 
       return (
         message,
-        [oldAttachment, newAttachment, differenceAttachment, cgDifferenceAttachment]
+        [oldAttachment, newAttachment, cgDifferenceAttachment]
       )
     }
   }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -26,9 +26,13 @@ extension Diffing where Value == UIImage {
       newAttachment.name = "failure"
       let differenceAttachment = XCTAttachment(image: difference)
       differenceAttachment.name = "difference"
+
+      let cgDifferenceAttachment = XCTAttachment(image: SnapshotTesting.cgDiff(old, new))
+      cgDifferenceAttachment.name = "cg_difference"
+
       return (
         message,
-        [oldAttachment, newAttachment, differenceAttachment]
+        [oldAttachment, newAttachment, differenceAttachment, cgDifferenceAttachment]
       )
     }
   }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -102,6 +102,17 @@ private func context(for cgImage: CGImage, data: UnsafeMutableRawPointer? = nil)
   return context
 }
 
+private func cgDiff(_ old: UIImage, _ new: UIImage) -> UIImage {
+  let width = max(old.size.width, new.size.width)
+  let height = max(old.size.height, new.size.height)
+  UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), true, 0)
+  new.draw(at: .zero)
+  old.draw(at: .zero, blendMode: .difference, alpha: 1)
+  let differenceImage = UIGraphicsGetImageFromCurrentImageContext()!
+  UIGraphicsEndImageContext()
+  return differenceImage
+}
+
 private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
   let oldCiImage = CIImage(cgImage: old.cgImage!)
   let newCiImage = CIImage(cgImage: new.cgImage!)

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -16,7 +16,7 @@ extension Diffing where Value == UIImage {
       fromData: { UIImage(data: $0, scale: UIScreen.main.scale)! }
     ) { old, new in
       guard !compare(old, new, precision: precision) else { return nil }
-//      let difference = SnapshotTesting.diff(old, new)
+      let difference = SnapshotTesting.diff(old, new)
       let message = new.size == old.size
         ? "Newly-taken snapshot does not match reference."
         : "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
@@ -24,15 +24,11 @@ extension Diffing where Value == UIImage {
       oldAttachment.name = "reference"
       let newAttachment = XCTAttachment(image: new)
       newAttachment.name = "failure"
-//      let differenceAttachment = XCTAttachment(image: difference)
-//      differenceAttachment.name = "difference"
-
-      let cgDifferenceAttachment = XCTAttachment(image: SnapshotTesting.cgDiff(old, new))
-      cgDifferenceAttachment.name = "cg_difference"
-
+      let differenceAttachment = XCTAttachment(image: difference)
+      differenceAttachment.name = "difference"
       return (
         message,
-        [oldAttachment, newAttachment, cgDifferenceAttachment]
+        [oldAttachment, newAttachment, differenceAttachment]
       )
     }
   }
@@ -106,7 +102,7 @@ private func context(for cgImage: CGImage, data: UnsafeMutableRawPointer? = nil)
   return context
 }
 
-private func cgDiff(_ old: UIImage, _ new: UIImage) -> UIImage {
+private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
   let width = max(old.size.width, new.size.width)
   let height = max(old.size.height, new.size.height)
   UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), true, 0)
@@ -115,17 +111,5 @@ private func cgDiff(_ old: UIImage, _ new: UIImage) -> UIImage {
   let differenceImage = UIGraphicsGetImageFromCurrentImageContext()!
   UIGraphicsEndImageContext()
   return differenceImage
-}
-
-private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
-  let oldCiImage = CIImage(cgImage: old.cgImage!)
-  let newCiImage = CIImage(cgImage: new.cgImage!)
-  let differenceFilter = CIFilter(name: "CIDifferenceBlendMode")!
-  differenceFilter.setValue(oldCiImage, forKey: kCIInputImageKey)
-  differenceFilter.setValue(newCiImage, forKey: kCIInputBackgroundImageKey)
-  let differenceCiImage = differenceFilter.outputImage!
-  let context = CIContext()
-  let differenceCgImage = context.createCGImage(differenceCiImage, from: differenceCiImage.extent)!
-  return UIImage(cgImage: differenceCgImage)
 }
 #endif


### PR DESCRIPTION
I looked into whether **performance of reporting snapshot failures** could be improved. Current code uses Core Image to generate diff image. I managed to gain some time by generating diff image with Core Graphics instead.

Measurements for single test which generates 6 snapshots. Results in seconds.

|  Scenario |  Run 1 | Run 2  | Run 3  | Run 4  | Run 5  | Run 6  | Run 7  | Run 8  | Run 9  | Run 10  | Min  | Max  | Average  |
|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
| Core Image  |  5,812 |  5,637 | 5,739  | 5,661  | 5,714  | 5,690  | 5,707  | 5,721  | 5,741  | 5,670  | 5,637  | 5,812  |  5,709 |
| Core Graphics  |  1,160 |	1,164	| 1,173 |	1,182 |	1,179 |	1,188 | 1,189	| 1,161 | 1,190 | 1,180 | 1,160 | 1,190 | 1,177 |
<br/>

Core Graphics version is **almost 5x faster**!

The resulting image is slightly different, but I think it still does the job well. Core Graphics images are sharper and slightly dimmer. Diff image for images with different sizes also changes a little due to coordinate system, I hope that's OK.

| Reference | Failure |  Core Image |  Core Graphics |
|---|---|---|---|
|  ![reference](https://user-images.githubusercontent.com/830743/63544997-a63dae00-c526-11e9-9abb-1ec9bfd4a37d.png)  | ![failure](https://user-images.githubusercontent.com/830743/63544996-a63dae00-c526-11e9-88ab-e7de7b28fe56.png)   |  ![ci_difference](https://user-images.githubusercontent.com/830743/63544521-b1dca500-c525-11e9-9453-f5b284cd7235.png) | ![cg_difference](https://user-images.githubusercontent.com/830743/63544520-b1440e80-c525-11e9-9469-eccaef36e18d.png) |
| ![another_reference](https://user-images.githubusercontent.com/830743/63544519-b1440e80-c525-11e9-88d8-816e4498645d.png)  |  ![another_failure](https://user-images.githubusercontent.com/830743/63544518-b1440e80-c525-11e9-8eb9-b7722fbee64c.png)  |  ![another_ci_difference](https://user-images.githubusercontent.com/830743/63544517-b1440e80-c525-11e9-92f6-3c60ae1c07b2.png)  | ![another_cg_difference](https://user-images.githubusercontent.com/830743/63544516-b1440e80-c525-11e9-92da-656eeb31c7ec.png)   |
| ![different_sizes-reference](https://user-images.githubusercontent.com/830743/63544526-b1dca500-c525-11e9-9fbd-60b34c84f3dd.png) |  ![different_sizes-failure](https://user-images.githubusercontent.com/830743/63544525-b1dca500-c525-11e9-8173-6d0706beff27.png)  |  ![different_sizes-ci_difference](https://user-images.githubusercontent.com/830743/63544524-b1dca500-c525-11e9-854b-9ed8d68745e9.png)  | ![different_sizes-cg_difference](https://user-images.githubusercontent.com/830743/63544522-b1dca500-c525-11e9-8632-fb87b7a9b214.png)   |












