### PR TITLE
1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ If your data can be represented as an image, text, or data, you can write a snap
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:
 
 ``` ruby
-github "pointfreeco/swift-snapshot-testing" ~> 1.5
+github "pointfreeco/swift-snapshot-testing" ~> 1.6
 ```
 
 > ⚠️ Warning: Carthage instructs you to drag frameworks into your Xcode project. Xcode may automatically attempt to link these frameworks to your app target. `SnapshotTesting.framework` is only compatible with test targets, so when you first add it to your project:
@@ -149,7 +149,7 @@ If your project uses [CocoaPods](https://cocoapods.org), add the pod to any appl
 
 ```ruby
 target 'MyAppTests' do
-  pod 'SnapshotTesting', '~> 1.5'
+  pod 'SnapshotTesting', '~> 1.6'
 end
 ```
 
@@ -159,7 +159,7 @@ If you want to use SnapshotTesting in a project that uses [SwiftPM](https://swif
 
 ```swift
 dependencies: [
-  .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.5.0"),
+  .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.6.0"),
 ]
 ```
 

--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "SnapshotTesting"
-  s.version = "1.5.0"
+  s.version = "1.6.0"
   s.summary = "Tests that save and assert against reference data"
 
   s.description = <<-DESC


### PR DESCRIPTION
Bug fixes and performance improvements 😆

- Add device sizes for split view variants of iPads (#209)
- Add recording to inline snapshotting (#212)
- Sort cURL strategy headers (#214)
- Add iOS minimum required deployment target to Package.swift (#215)
- Allow dynamic size of views based on trait collection content sizes (#217)
- Disable bitcode (#221) 
- Improve `_assertInlineSnapshot` ergonomics and tests (#231 and #232)
- Use `URL.init(fileURLWithPath:isDirectory:)` to avoid file IO (#236)
- Speed up image diffing (#248)
- Improve image diff drawing performance (#249)

Thanks to @Sherlouk, @crayment, @jayhickey, @MarianaMeireles, @pavel-y-ivanov, @ferranpujolcamins, @kirillyakimovich, and @mr-v for making this release happen!