### PR TITLE
Import FoundationNetwork if available

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension Snapshotting where Value == URLRequest, Format == String {
   /// A snapshot strategy for comparing requests based on raw equality.

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -8,6 +8,9 @@ import SpriteKit
 #if os(iOS) || os(macOS)
 import WebKit
 #endif
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 final class SnapshotTestingTests: XCTestCase {
   override func setUp() {


### PR DESCRIPTION
👋,
On Swift 5.1 on Linux, `swift-snapshot-testing` is not compiling https://travis-ci.org/danger/swift/jobs/589176028#L538
This is related to https://forums.swift.org/t/foundationnetworking/24769.
Conditionally importing `FoundationNetworking` should fix that.