### PR TITLE
Support for swift:5.1 on linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM norionomura/swift:swift-5.0-branch
+FROM swift:5.1
 
 WORKDIR /package
 

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension Snapshotting where Value == URLRequest, Format == String {
   /// A snapshot strategy for comparing requests based on raw equality.

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -1,5 +1,8 @@
 @testable import SnapshotTesting
 import XCTest
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 #if os(iOS) || os(macOS) || os(tvOS)
 import SceneKit


### PR DESCRIPTION
I've run into issues building the package with swift:5.1, throwing the following in a few places:

```
/package/Sources/SnapshotTesting/Snapshotting/URLRequest.swift:3:39: error: use of undeclared type 'URLRequest'
extension Snapshotting where Value == URLRequest, Format == String {
                                      ^~~~~~~~~~
...
```

I've tested it with these image variants and they all pass:

```
FROM norionomura/swift:swift-5.0-branch
FROM swift:5.0
FROM swift:5.1
```

So it could go in with either - or maybe it's worth running the tests for both 5.0 and 5.1?

Hope that helps!