### PR TITLE
Support for RTL layout testing with Xcode 11 test plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ end
   - **Subclass-free.** Assert from any XCTest case or Quick spec.
   - **Device-agnostic snapshots.** Render views and view controllers for specific devices and trait collections from a single simulator.
   - **First-class Xcode support.** Image differences are captured as XCTest attachments. Text differences are rendered in inline error messages.
+  - **Support for Xcode Test Plans**. Just add `SNAPSHOT_CONFIGURATION_NAME` environment variable to every Configuration in your test plan (with distinctive names as values) to save separate snapshots for each one of them. It can be used for making UI snapshots with different langauges and locales.
   - **Supports any platform that supports Swift.** Write snapshot tests for iOS, Linux, macOS, and tvOS.
   - **SceneKit, SpriteKit, and WebKit support.** Most snapshot testing libraries don't support these view subclasses.
   - **`Codable` support**. Snapshot encodable data structures into their [JSON](Documentation/Available-Snapshot-Strategies.md#json) and [property list](Documentation/Available-Snapshot-Strategies.md#plist) representations.

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -178,8 +178,8 @@ public func verifySnapshot<Value, Format>(
         ?? fileUrl
           .deletingLastPathComponent()
           .appendingPathComponent("__Snapshots__")
-          .appendingPathComponentIfExists(configurationName)
           .appendingPathComponent(fileName)
+          .appendingPathComponentIfExists(configurationName)
 
       let identifier: String
       if let name = name {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -170,11 +170,15 @@ public func verifySnapshot<Value, Format>(
     do {
       let fileUrl = URL(fileURLWithPath: "\(file)", isDirectory: false)
       let fileName = fileUrl.deletingPathExtension().lastPathComponent
+      
+      /// Support for Xcode 11 test plans and running tests multiple times with different configurations
+      let configurationName = ProcessInfo.processInfo.environment["SNAPSHOT_CONFIGURATION_NAME"]
 
       let snapshotDirectoryUrl = snapshotDirectory.map { URL(fileURLWithPath: $0, isDirectory: true) }
         ?? fileUrl
           .deletingLastPathComponent()
           .appendingPathComponent("__Snapshots__")
+          .appendingPathComponentIfExists(configurationName)
           .appendingPathComponent(fileName)
 
       let identifier: String
@@ -293,4 +297,12 @@ func sanitizePathComponent(_ string: String) -> String {
   return string
     .replacingOccurrences(of: "\\W+", with: "-", options: .regularExpression)
     .replacingOccurrences(of: "^-|-$", with: "", options: .regularExpression)
+}
+
+private extension URL {
+  func appendingPathComponentIfExists(_ pathComponent: String?) -> URL {
+    guard let pathComponent = pathComponent else { return self }
+    
+    return appendingPathComponent(pathComponent)
+  }
 }

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -11,6 +11,12 @@ import UIKit
 import WebKit
 #endif
 
+// Explanation for not providing `layoutDirection` trait in base traits for devices:
+// .init(layoutDirection: .leftToRight) is commented out because of http://www.openradar.me/radar?id=5044259694575616
+// When tests are ran with RTL language (e.g. Arabic), this override does not fully change layout to LTR (due to issue linked above)
+// which causes layout to not be correct on snapshots.
+// When tests are ran with LTR langauge (e.g. English), this override is not needed.
+
 #if os(iOS) || os(tvOS)
 public struct ViewImageConfig {
   public enum Orientation {
@@ -347,8 +353,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .SRGB),
 //        .init(displayScale: 2),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .available),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]
@@ -375,8 +381,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .P3),
 //        .init(displayScale: 2),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .available),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]
@@ -403,8 +409,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .P3),
 //        .init(displayScale: 3),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .available),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]
@@ -431,8 +437,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .P3),
 //        .init(displayScale: 3),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .available),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]
@@ -459,8 +465,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .P3),
 //        .init(displayScale: 2),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .unavailable),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]
@@ -487,8 +493,8 @@ extension UITraitCollection {
       let base: [UITraitCollection] = [
 //        .init(displayGamut: .P3),
 //        .init(displayScale: 3),
+//        .init(layoutDirection: .leftToRight), // See explanation at the beginning of the file
         .init(forceTouchCapability: .available),
-        .init(layoutDirection: .leftToRight),
         .init(preferredContentSizeCategory: .medium),
         .init(userInterfaceIdiom: .phone)
       ]


### PR DESCRIPTION
This PR adds support for `SNAPSHOT_CONFIGURATION_NAME` environment variable which can be used in Test Plans configurations. When aforementioned variable exists, another level of directory nesting is added to store separate snapshots for each configuration.

Additionally, to fully support RTL layout testing, `.leftToRight` traits have been removed from `base` trait sets for each snapshotting device. This trait override caused RTL UIs to not be correctly rendered (see http://www.openradar.me/radar?id=5044259694575616).

See #168 for more background for this PR.