### PR TITLE
Add instructions to specifically add as a SPM test dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,20 @@ dependencies: [
 ]
 ```
 
+Next, add `SnapshotTesting` as a dependency of your test target:
+
+```swift
+targets: [
+    .target(
+        name: "MyApp",
+        dependencies: [],
+        path: "Sources"),
+    .testTarget(
+        name: "MyAppTests",
+        dependencies: ["MyApp", "SnapshotTesting"])
+]
+```
+
 ### Carthage
 
 If you use [Carthage](https://github.com/Carthage/Carthage), you can add the following dependency to your `Cartfile`:

--- a/README.md
+++ b/README.md
@@ -149,13 +149,8 @@ Next, add `SnapshotTesting` as a dependency of your test target:
 
 ```swift
 targets: [
-    .target(
-        name: "MyApp",
-        dependencies: [],
-        path: "Sources"),
-    .testTarget(
-        name: "MyAppTests",
-        dependencies: ["MyApp", "SnapshotTesting"])
+  .target(name: "MyApp", dependencies: [], path: "Sources"),
+  .testTarget(name: "MyAppTests", dependencies: ["MyApp", "SnapshotTesting"])
 ]
 ```
 


### PR DESCRIPTION
Since the repo name and the actual target/product have different names, this is a tad confusing. I thought it would be good to specifically outline this.