### PR TITLE
Fix compilation failure on Linux + Swift 5.1+ - fixes issue #269

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 extension Snapshotting where Value == URLRequest, Format == String {
   /// A snapshot strategy for comparing requests based on raw equality.


### PR DESCRIPTION
This PR fixes a compilation bug that I raised in https://github.com/pointfreeco/swift-snapshot-testing/issues/269.

On Linux `Foundation` does not contain `URLRequest` anymore, 
but was moved to `FoundationNetworking`.
See: https://stackoverflow.com/a/58606520/6043526 or https://forums.swift.org/t/pitch-move-urlsession-to-new-foundationnetworking-module/14002/25.

This PR fixes the compilation error that was caused by this:
```swift
Sources/SnapshotTesting/Snapshotting/URLRequest.swift:3:39: error: use of undeclared type 'URLRequest'
```
