### PR TITLE
Support Swift Tools Version 5.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 import Foundation
 import PackageDescription
 


### PR DESCRIPTION
We shouldn't prevent SnapshotTesting from being installed on 5.0...