### PR TITLE
Swift 5.2 Fix

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -36,7 +36,9 @@ extension Snapshotting where Value == UIView, Format == UIImage {
 
 extension Snapshotting where Value == UIView, Format == String {
   /// A snapshot strategy for comparing views based on a recursive description of their properties and hierarchies.
-  public static let recursiveDescription = Snapshotting<UIView, String>.recursiveDescription()
+  public static var recursiveDescription: Snapshotting {
+    return Snapshotting.recursiveDescription()
+  }
 
   /// A snapshot strategy for comparing views based on a recursive description of their properties and hierarchies.
   public static func recursiveDescription(

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -78,7 +78,9 @@ extension Snapshotting where Value == UIViewController, Format == String {
   }
 
   /// A snapshot strategy for comparing view controller views based on a recursive description of their properties and hierarchies.
-  public static let recursiveDescription = Snapshotting.recursiveDescription()
+  public static var recursiveDescription: Snapshotting {
+    return Snapshotting.recursiveDescription()
+  }
 
   /// A snapshot strategy for comparing view controller views based on a recursive description of their properties and hierarchies.
   ///


### PR DESCRIPTION
Strangely the project builds just fine without these changes, but some Point-Free episode code samples that include SnapshotTesting as an SPM package won't compile in Xcode 11.4 with a "Circular reference" error. Changing to a computed var fixes, though!