### PR TITLE
Pass traits when snapshotting recursiveDescription in UIViewController

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -98,7 +98,7 @@ extension Snapshotting where Value == UIViewController, Format == String {
         prepareView(
           config: .init(safeArea: config.safeArea, size: size ?? config.size, traits: config.traits),
           drawHierarchyInKeyWindow: false,
-          traits: .init(),
+          traits: traits,
           view: viewController.view,
           viewController: viewController
         )

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -692,6 +692,33 @@ final class SnapshotTestingTests: XCTestCase {
     #endif
   }
 
+  func testTraitsWithViewController() {
+    #if os(iOS)
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .title1)
+    label.adjustsFontForContentSizeCategory = true
+    label.text = "What's the point?"
+
+    let viewController = UIViewController()
+    viewController.view.addSubview(label)
+
+    label.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      label.leadingAnchor.constraint(equalTo: viewController.view.layoutMarginsGuide.leadingAnchor),
+      label.topAnchor.constraint(equalTo: viewController.view.layoutMarginsGuide.topAnchor),
+      label.trailingAnchor.constraint(equalTo: viewController.view.layoutMarginsGuide.trailingAnchor)
+    ])
+
+    allContentSizes.forEach { name, contentSize in
+      assertSnapshot(
+        matching: viewController,
+        as: .recursiveDescription(on: .iPhoneSe, traits: .init(preferredContentSizeCategory: contentSize)),
+        named: "label-\(name)"
+      )
+    }
+    #endif
+  }
+
   func testUIView() {
     #if os(iOS)
     let view = UIButton(type: .contactAdd)

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 69.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 63.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 57.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 51.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-medium.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-medium.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-medium.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-accessibility-medium.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 45.6667); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 40.6667); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 38.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 36); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-small.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-small.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-small.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-extra-small.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 30); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-large.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-large.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-large.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 33.6667); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-medium.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-medium.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-small.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-small.txt
@@ -1,0 +1,2 @@
+<UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
+   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-small.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testTraitsWithViewController.label-small.txt
@@ -1,2 +1,2 @@
 <UIView; frame = (0 0; 320 568); autoresize = W+H; layer = <CALayer>>
-   | <UILabel; frame = (16 20; 288 32.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>
+   | <UILabel; frame = (16 20; 288 31.3333); text = 'What's the point?'; userInteractionEnabled = NO; layer = <_UILabelLayer>>


### PR DESCRIPTION
Hi,

I found that the traits that you could set in recursiveDescription of UIViewController weren't passed. My goal was to test the layout of labels with a preferred size category, which I use to test the fix. See commits if anything is unclear!

Cheers