### PR TITLE
Make image diffing strategies custom scale aware

### DIFF
--- a/SnapshotTesting.xcodeproj/project.pbxproj
+++ b/SnapshotTesting.xcodeproj/project.pbxproj
@@ -32,10 +32,12 @@
 		19CAE304A06A92323E7C225C /* testCreateSnapshotMultiLine.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C685ECE195C23560AFD1456 /* testCreateSnapshotMultiLine.1.swift */; };
 		1A0FB107B2820F9B33EFE2BB /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F429C62A87AC95E13E2D78 /* String.swift */; };
 		1ABB68DCE39CE794B07296A7 /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AAFA3BB389939B18F4D7187 /* UIViewController.swift */; };
+		1AF02DC6F0CD8B36DD2CEEB5 /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2750685230CC3BC17BDEAB /* CGPath.swift */; };
 		1D24E76D17FCE8E61B1F0387 /* testCreateSnapshotEscapedNewlineLastLine.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F1FEF91276E0D2BEFD9BC6 /* testCreateSnapshotEscapedNewlineLastLine.1.swift */; };
 		1FF2453D55C601BDC68646D9 /* testUpdateSnapshotWithLongerExtendedDelimiter2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7085488C51876C1E9B871C /* testUpdateSnapshotWithLongerExtendedDelimiter2.1.swift */; };
 		2336ECD86073FAB4CFC26CC2 /* InlineSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6D3BC50BC4692DC6D9FAE0F /* InlineSnapshotTests.swift */; };
 		2706E738D0BF540260D1F776 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E01FF29B2959DE5FD093FB /* CALayer.swift */; };
+		27E2E64971E40DB5E6E84BB6 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599AA3651C4CEE464302CFDD /* NSBezierPath.swift */; };
 		28106F59B265148F2CB38B5B /* CaseIterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B843712AB555B46BA6E4EC2A /* CaseIterable.swift */; };
 		29602B6DD2A43E1C13DF1D42 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646ABA578B433C2F4DD4A086 /* Async.swift */; };
 		2A062189ED2218A03B1CB3CB /* testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4796690CC049B52358D7173A /* testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift */; };
@@ -55,15 +57,13 @@
 		3FDA79CD7E2D26217A5132DA /* NSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9D57E3B929139A0C14AEBA7 /* NSView.swift */; };
 		42B1EA1619E926A4391D176F /* Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = A76261A778A1B8C06EB7E1B4 /* Description.swift */; };
 		42BCD8FC5433734A7BD80486 /* SnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD2F74288CF52A13C9BB497 /* SnapshotTestCase.swift */; };
-		431F526524633AAD00F256F4 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431F526124633A9D00F256F4 /* SwiftUIView.swift */; };
-		431F526724633AAE00F256F4 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431F526124633A9D00F256F4 /* SwiftUIView.swift */; };
+		42EEB5E183FA787232DCF756 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641BBEB31120E3B7FE5EA51 /* UIBezierPath.swift */; };
 		436C10BC8313288D84733DC5 /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D04C79E5D44F1874BBACB11 /* UIView.swift */; };
-		436E95562463421500DE7A44 /* SnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA789F513A8B1E8EF5BF81E2 /* SnapshotTestingTests.swift */; };
-		436E95572463437D00DE7A44 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 431F526124633A9D00F256F4 /* SwiftUIView.swift */; };
 		4521C5D2FE3CE1784C44A210 /* XCTAttachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BE8DE5E8A102E1012CD0C95 /* XCTAttachment.swift */; };
 		45FAA85BB7198113155FD27F /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 646ABA578B433C2F4DD4A086 /* Async.swift */; };
 		468C9CBF306D8D8F87BC35AC /* SnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3BBC3220F45BA5E71F819602 /* SnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4A95F6990FFA0B2F52CAC260 /* Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = F479E2BD835B9641B85EB51E /* Internal.swift */; };
+		4CF683A5FA0EDF2C6ABC8B10 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641BBEB31120E3B7FE5EA51 /* UIBezierPath.swift */; };
 		4D153EF65CD179C5359C088C /* testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD3B175977519BCF6179FD0 /* testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift */; };
 		4D36F6FD7EC4C9D5EFEB1B54 /* WaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86810F80142B1A3265C4F74 /* WaitTests.swift */; };
 		4DCF3527100FE3577AB7074B /* Snapshotting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D7D5B93AE097C0B92B78931 /* Snapshotting.swift */; };
@@ -77,6 +77,7 @@
 		5A5F87646FB492693503E9C3 /* SnapshotTesting.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 50945BA2653A2A96CFA62431 /* SnapshotTesting.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5C7623E2C040A67AEF4BE329 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D7CFCA42A4D2168436F6C1 /* Codable.swift */; };
 		5C9B450582B24CD89D7F9977 /* testUpdateSnapshot.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FE81FC04984B93B0C27FA6 /* testUpdateSnapshot.1.swift */; };
+		5E7F4795AFED0D8D4E1D75A6 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2641BBEB31120E3B7FE5EA51 /* UIBezierPath.swift */; };
 		5F4CD3628962897AC0D56799 /* testUpdateSeveralSnapshotsSwapingLines1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86AF3E4E28A1292D02E080C7 /* testUpdateSeveralSnapshotsSwapingLines1.1.swift */; };
 		620758875CDFB7D9C6442A75 /* CaseIterable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B843712AB555B46BA6E4EC2A /* CaseIterable.swift */; };
 		63F5F347F14D6F8997D29867 /* testUpdateSeveralSnapshotsWithMoreLines.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEC001D7DB94ECB4F5A2CF9 /* testUpdateSeveralSnapshotsWithMoreLines.1.swift */; };
@@ -96,9 +97,12 @@
 		785ECE356ECA7C1564D99932 /* NSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48914A258708D7AC11DC12EF /* NSImage.swift */; };
 		7866CC909D70D49D1EEF9F45 /* testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4796690CC049B52358D7173A /* testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift */; };
 		789E86CBD26991DA22BA051A /* testCreateSnapshotWithLongerExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA9C51757FC5DC679F5DC72 /* testCreateSnapshotWithLongerExtendedDelimiter1.1.swift */; };
+		7A113ED6F1950924A9012428 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7585E299A8FF3416E005E3FD /* SwiftUIView.swift */; };
 		7B9F0DFC589C66887A37F0FB /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA7A398EA6B5594232933158 /* URLRequest.swift */; };
 		7C48053A90BCB45B35C432F4 /* testUpdateSnapshot.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FE81FC04984B93B0C27FA6 /* testUpdateSnapshot.1.swift */; };
 		7EDE9C3850EC4AF1100E6AB7 /* WaitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86810F80142B1A3265C4F74 /* WaitTests.swift */; };
+		8442C5AE49466F0F0CB6BD9C /* SnapshotTestingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA789F513A8B1E8EF5BF81E2 /* SnapshotTestingTests.swift */; };
+		87B0D39F14038FF162ADA25A /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2750685230CC3BC17BDEAB /* CGPath.swift */; };
 		87D3745DBD172E3E6427190F /* Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F831EAAFB97204ECD0B879 /* Any.swift */; };
 		8BDA8D067C1A9BDD7EFB1E78 /* String+SpecialCharacters.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092873A7A5D6DA623E352 /* String+SpecialCharacters.swift */; };
 		8C428A751E6342E2CE46E4CB /* NSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB124D18325606D35B7027A6 /* NSViewController.swift */; };
@@ -106,6 +110,7 @@
 		90555C6EB17BD465E901043A /* AssertInlineSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD800FD3282956340AD7706A /* AssertInlineSnapshot.swift */; };
 		9068EBD3D0BB87B3CB76FFBA /* Diff.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EEE36D7D9E53E70DABA3996 /* Diff.swift */; };
 		929525DD0395B3F978119D0B /* testUpdateSnapshotCombined1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A6FCFFED1BDCF9090E5FEC /* testUpdateSnapshotCombined1.1.swift */; };
+		92A3B11C03C0A4636DA3CB62 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599AA3651C4CEE464302CFDD /* NSBezierPath.swift */; };
 		92F3C506872F3E6C289A861F /* testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A637034F06E7DF38F2339F4 /* testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift */; };
 		9399D33F028C4B110119B641 /* PlistEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B960E2B6E4AAE0BA50F27B /* PlistEncoder.swift */; };
 		93F5DF248D854C8E353BCA25 /* PlistEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B960E2B6E4AAE0BA50F27B /* PlistEncoder.swift */; };
@@ -131,10 +136,12 @@
 		AB307DF4664ECD682782740C /* testWait.1.txt in Resources */ = {isa = PBXBuildFile; fileRef = 53F63F2CD9E9F164EB7AF753 /* testWait.1.txt */; };
 		AE77649A377D5328DC91D19B /* AssertSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0B236137C960C05554D4310 /* AssertSnapshot.swift */; };
 		AEA906B0259465877DCED2AC /* NSViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB124D18325606D35B7027A6 /* NSViewController.swift */; };
+		AF0B20C84F8CFA4231DAA1E5 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7585E299A8FF3416E005E3FD /* SwiftUIView.swift */; };
 		AF4170D746DA3C5F89010291 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58583084B2E2BC023E981D2B /* Data.swift */; };
 		B30E8815010C2E79DD90B3C0 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58583084B2E2BC023E981D2B /* Data.swift */; };
 		B31F766A012E912D8034B3E2 /* testCreateSnapshotEscapedNewlineLastLine.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F1FEF91276E0D2BEFD9BC6 /* testCreateSnapshotEscapedNewlineLastLine.1.swift */; };
 		B5DDFD7AB905028533949838 /* Codable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D7CFCA42A4D2168436F6C1 /* Codable.swift */; };
+		B67546FC373990003C3C4D49 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599AA3651C4CEE464302CFDD /* NSBezierPath.swift */; };
 		B7C6F1A74C6D9DF70ACC52DB /* UIImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 810407271A6CB90161DCE6A0 /* UIImage.swift */; };
 		BA6099AF5DBC1D12C3066D14 /* String+SpecialCharacters.swift in Sources */ = {isa = PBXBuildFile; fileRef = D49092873A7A5D6DA623E352 /* String+SpecialCharacters.swift */; };
 		BA9E7BCC44BCFA7AB29C7057 /* testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A637034F06E7DF38F2339F4 /* testCreateSnapshotWithExtendedDelimiterSingleLine2.1.swift */; };
@@ -156,15 +163,6 @@
 		C7A32C62FABEA6CECB907389 /* testUpdateSnapshotWithExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D7D0D81B7E35C6284A3E65 /* testUpdateSnapshotWithExtendedDelimiter1.1.swift */; };
 		C97E2A9B0EC799E08B77B723 /* testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CD3B175977519BCF6179FD0 /* testUpdateSnapshotWithShorterExtendedDelimiter1.1.swift */; };
 		C9C12C6C91FB96E02BBA8A8F /* testCreateSnapshotWithShorterExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE91B5904B3F67A3A01610C8 /* testCreateSnapshotWithShorterExtendedDelimiter1.1.swift */; };
-		CA26E171242D0219008D08A0 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16D242D0219008D08A0 /* NSBezierPath.swift */; };
-		CA26E172242D0219008D08A0 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16D242D0219008D08A0 /* NSBezierPath.swift */; };
-		CA26E173242D0219008D08A0 /* NSBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16D242D0219008D08A0 /* NSBezierPath.swift */; };
-		CA26E175242D0219008D08A0 /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16E242D0219008D08A0 /* CGPath.swift */; };
-		CA26E176242D0219008D08A0 /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16E242D0219008D08A0 /* CGPath.swift */; };
-		CA26E177242D0219008D08A0 /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16E242D0219008D08A0 /* CGPath.swift */; };
-		CA26E179242D0219008D08A0 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16F242D0219008D08A0 /* UIBezierPath.swift */; };
-		CA26E17A242D0219008D08A0 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16F242D0219008D08A0 /* UIBezierPath.swift */; };
-		CA26E17B242D0219008D08A0 /* UIBezierPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA26E16F242D0219008D08A0 /* UIBezierPath.swift */; };
 		CBC57ED5427F5EBD18FDCEFC /* testCreateSnapshotWithLongerExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAA9C51757FC5DC679F5DC72 /* testCreateSnapshotWithLongerExtendedDelimiter1.1.swift */; };
 		CC1CC535032FA027BC50AB5B /* testCreateSnapshotWithShorterExtendedDelimiter2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADACB597E6A3CAC5BFEEFB05 /* testCreateSnapshotWithShorterExtendedDelimiter2.1.swift */; };
 		CE53F597D12C921A3DA2E8B0 /* NSImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48914A258708D7AC11DC12EF /* NSImage.swift */; };
@@ -173,6 +171,7 @@
 		D3FE132E866B8AF0D5F4C8DF /* testCreateSnapshotWithExtendedDelimiter1.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FB18BB1F44D13D5C5FE09A6 /* testCreateSnapshotWithExtendedDelimiter1.1.swift */; };
 		D5483007C407B1AC42A9E391 /* SceneKit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5580E7AC2CEBEA656780C7A9 /* SceneKit.swift */; };
 		D5EED6FE1C8F85CE32392066 /* TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C676C30FCAE10DB1773832 /* TestHelpers.swift */; };
+		DAAEB108C97963D4BF3C74E1 /* CGPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2750685230CC3BC17BDEAB /* CGPath.swift */; };
 		DC925700DE66F9134D3E47EA /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04F429C62A87AC95E13E2D78 /* String.swift */; };
 		DE888645B9529A2CCDE24580 /* testCreateSnapshotWithExtendedDelimiter2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A69D6A4D06EB76C77493EB7 /* testCreateSnapshotWithExtendedDelimiter2.1.swift */; };
 		DFAA125AE62C89E28F9762C0 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58583084B2E2BC023E981D2B /* Data.swift */; };
@@ -182,6 +181,7 @@
 		E2E1BA4E82EBF5D7E7533485 /* Any.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F831EAAFB97204ECD0B879 /* Any.swift */; };
 		E3E64AA7C25386DE50DB0995 /* CALayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96E01FF29B2959DE5FD093FB /* CALayer.swift */; };
 		E4E9D9D29275B05B86B1B35E /* testCreateSnapshotSingleLine.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0BCE5A339D74CD4AE05C2 /* testCreateSnapshotSingleLine.1.swift */; };
+		E5EA11B0A1E1194E4285920E /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7585E299A8FF3416E005E3FD /* SwiftUIView.swift */; };
 		E66A02C861A316EDB4377C2E /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F6B5B3AB021FA3CD7519733 /* View.swift */; };
 		E74DAB4391AD53DABB1B414A /* testUpdateSeveralSnapshotsSwapingLines2.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77BE996AE7868E9B58D6C74 /* testUpdateSeveralSnapshotsSwapingLines2.1.swift */; };
 		E7A986FC4CE72492A5A2AFD7 /* testCreateSnapshotSingleLine.1.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47F0BCE5A339D74CD4AE05C2 /* testCreateSnapshotSingleLine.1.swift */; };
@@ -271,13 +271,14 @@
 		10213E0E8B550596F75463C3 /* Wait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Wait.swift; sourceTree = "<group>"; };
 		1BD7AFAF336357D01E6E1E05 /* SnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EDE232DB652745F05B478F4 /* testCreateSnapshotWithLongerExtendedDelimiter2.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotWithLongerExtendedDelimiter2.1.swift; sourceTree = "<group>"; };
+		1F2750685230CC3BC17BDEAB /* CGPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGPath.swift; sourceTree = "<group>"; };
 		1FB18BB1F44D13D5C5FE09A6 /* testCreateSnapshotWithExtendedDelimiter1.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotWithExtendedDelimiter1.1.swift; sourceTree = "<group>"; };
+		2641BBEB31120E3B7FE5EA51 /* UIBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBezierPath.swift; sourceTree = "<group>"; };
 		2A69D6A4D06EB76C77493EB7 /* testCreateSnapshotWithExtendedDelimiter2.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotWithExtendedDelimiter2.1.swift; sourceTree = "<group>"; };
 		32BC721A155DB7D81BE69683 /* testUpdateSeveralSnapshotsWithLessLines.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testUpdateSeveralSnapshotsWithLessLines.1.swift; sourceTree = "<group>"; };
 		34D7CFCA42A4D2168436F6C1 /* Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Codable.swift; sourceTree = "<group>"; };
 		3BBC3220F45BA5E71F819602 /* SnapshotTesting.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapshotTesting.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4055310797F1D4813ABD0359 /* SpriteKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteKit.swift; sourceTree = "<group>"; };
-		431F526124633A9D00F256F4 /* SwiftUIView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUIView.swift; sourceTree = "<group>"; };
 		4796690CC049B52358D7173A /* testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testUpdateSnapshotWithShorterExtendedDelimiter2.1.swift; sourceTree = "<group>"; };
 		47F0BCE5A339D74CD4AE05C2 /* testCreateSnapshotSingleLine.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotSingleLine.1.swift; sourceTree = "<group>"; };
 		48914A258708D7AC11DC12EF /* NSImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSImage.swift; sourceTree = "<group>"; };
@@ -289,11 +290,13 @@
 		53F63F2CD9E9F164EB7AF753 /* testWait.1.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = testWait.1.txt; sourceTree = "<group>"; };
 		5580E7AC2CEBEA656780C7A9 /* SceneKit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneKit.swift; sourceTree = "<group>"; };
 		58583084B2E2BC023E981D2B /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		599AA3651C4CEE464302CFDD /* NSBezierPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSBezierPath.swift; sourceTree = "<group>"; };
 		5AAFA3BB389939B18F4D7187 /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		5CD2F74288CF52A13C9BB497 /* SnapshotTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotTestCase.swift; sourceTree = "<group>"; };
 		619A277E9C7B85515EC88C84 /* Diffing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Diffing.swift; sourceTree = "<group>"; };
 		6244D0EADF210BE6E3CE2EE7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		646ABA578B433C2F4DD4A086 /* Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
+		7585E299A8FF3416E005E3FD /* SwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIView.swift; sourceTree = "<group>"; };
 		810407271A6CB90161DCE6A0 /* UIImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImage.swift; sourceTree = "<group>"; };
 		8563DC0D660D87E1CDE5D696 /* SnapshotTestingTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = SnapshotTestingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		86367454DF23E14D681FDE27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -316,9 +319,6 @@
 		B843712AB555B46BA6E4EC2A /* CaseIterable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseIterable.swift; sourceTree = "<group>"; };
 		B8F1FEF91276E0D2BEFD9BC6 /* testCreateSnapshotEscapedNewlineLastLine.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotEscapedNewlineLastLine.1.swift; sourceTree = "<group>"; };
 		C13AB875AB58FF3BCAC1AA66 /* testCreateSnapshotWithExtendedDelimiterSingleLine1.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testCreateSnapshotWithExtendedDelimiterSingleLine1.1.swift; sourceTree = "<group>"; };
-		CA26E16D242D0219008D08A0 /* NSBezierPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSBezierPath.swift; sourceTree = "<group>"; };
-		CA26E16E242D0219008D08A0 /* CGPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CGPath.swift; sourceTree = "<group>"; };
-		CA26E16F242D0219008D08A0 /* UIBezierPath.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBezierPath.swift; sourceTree = "<group>"; };
 		CB124D18325606D35B7027A6 /* NSViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSViewController.swift; sourceTree = "<group>"; };
 		D1FE81FC04984B93B0C27FA6 /* testUpdateSnapshot.1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testUpdateSnapshot.1.swift; sourceTree = "<group>"; };
 		D3B960E2B6E4AAE0BA50F27B /* PlistEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistEncoder.swift; sourceTree = "<group>"; };
@@ -513,19 +513,19 @@
 				F8F831EAAFB97204ECD0B879 /* Any.swift */,
 				96E01FF29B2959DE5FD093FB /* CALayer.swift */,
 				B843712AB555B46BA6E4EC2A /* CaseIterable.swift */,
-				CA26E16E242D0219008D08A0 /* CGPath.swift */,
+				1F2750685230CC3BC17BDEAB /* CGPath.swift */,
 				34D7CFCA42A4D2168436F6C1 /* Codable.swift */,
 				58583084B2E2BC023E981D2B /* Data.swift */,
 				A76261A778A1B8C06EB7E1B4 /* Description.swift */,
-				CA26E16D242D0219008D08A0 /* NSBezierPath.swift */,
+				599AA3651C4CEE464302CFDD /* NSBezierPath.swift */,
 				48914A258708D7AC11DC12EF /* NSImage.swift */,
 				E9D57E3B929139A0C14AEBA7 /* NSView.swift */,
 				CB124D18325606D35B7027A6 /* NSViewController.swift */,
 				5580E7AC2CEBEA656780C7A9 /* SceneKit.swift */,
 				4055310797F1D4813ABD0359 /* SpriteKit.swift */,
 				04F429C62A87AC95E13E2D78 /* String.swift */,
-				CA26E16F242D0219008D08A0 /* UIBezierPath.swift */,
-				431F526124633A9D00F256F4 /* SwiftUIView.swift */,
+				7585E299A8FF3416E005E3FD /* SwiftUIView.swift */,
+				2641BBEB31120E3B7FE5EA51 /* UIBezierPath.swift */,
 				810407271A6CB90161DCE6A0 /* UIImage.swift */,
 				0D04C79E5D44F1874BBACB11 /* UIView.swift */,
 				5AAFA3BB389939B18F4D7187 /* UIViewController.swift */,
@@ -646,6 +646,8 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
+				TargetAttributes = {
+				};
 			};
 			buildConfigurationList = D9A4BF45876C849A308801A2 /* Build configuration list for PBXProject "SnapshotTesting" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -705,6 +707,7 @@
 				52B7C3800F08E80D7BA8600D /* AssertSnapshot.swift in Sources */,
 				1420B1BBC10CFF4D03C8AA67 /* Async.swift in Sources */,
 				2706E738D0BF540260D1F776 /* CALayer.swift in Sources */,
+				1AF02DC6F0CD8B36DD2CEEB5 /* CGPath.swift in Sources */,
 				6E50CE7921A0D62C78E85637 /* CaseIterable.swift in Sources */,
 				8C4AC3C0BAAA1275BF205637 /* Codable.swift in Sources */,
 				DFAA125AE62C89E28F9762C0 /* Data.swift in Sources */,
@@ -712,21 +715,20 @@
 				0FA2819099AC626FF01F2E97 /* Diff.swift in Sources */,
 				038184DBCE934EA8E69E075B /* Diffing.swift in Sources */,
 				4A95F6990FFA0B2F52CAC260 /* Internal.swift in Sources */,
+				92A3B11C03C0A4636DA3CB62 /* NSBezierPath.swift in Sources */,
 				785ECE356ECA7C1564D99932 /* NSImage.swift in Sources */,
 				3FDA79CD7E2D26217A5132DA /* NSView.swift in Sources */,
-				436E95572463437D00DE7A44 /* SwiftUIView.swift in Sources */,
 				08C8278A038756916D597D02 /* NSViewController.swift in Sources */,
 				9399D33F028C4B110119B641 /* PlistEncoder.swift in Sources */,
 				D5483007C407B1AC42A9E391 /* SceneKit.swift in Sources */,
 				EB96DB74099A6385283A1299 /* SnapshotTestCase.swift in Sources */,
 				4DCF3527100FE3577AB7074B /* Snapshotting.swift in Sources */,
-				CA26E176242D0219008D08A0 /* CGPath.swift in Sources */,
 				648E0BF61716417CE60ADF13 /* SpriteKit.swift in Sources */,
 				8BDA8D067C1A9BDD7EFB1E78 /* String+SpecialCharacters.swift in Sources */,
 				F091F6AC6DA030FD96240A5E /* String.swift in Sources */,
-				CA26E172242D0219008D08A0 /* NSBezierPath.swift in Sources */,
+				AF0B20C84F8CFA4231DAA1E5 /* SwiftUIView.swift in Sources */,
+				42EEB5E183FA787232DCF756 /* UIBezierPath.swift in Sources */,
 				2D9BA837D802B7347244178B /* UIImage.swift in Sources */,
-				CA26E17A242D0219008D08A0 /* UIBezierPath.swift in Sources */,
 				3CB93CF15AA49A2CB461D45E /* UIView.swift in Sources */,
 				1ABB68DCE39CE794B07296A7 /* UIViewController.swift in Sources */,
 				30413A9E862B77B868A57B65 /* URLRequest.swift in Sources */,
@@ -745,6 +747,7 @@
 				AE77649A377D5328DC91D19B /* AssertSnapshot.swift in Sources */,
 				29602B6DD2A43E1C13DF1D42 /* Async.swift in Sources */,
 				AAE5EED880A834F69554115C /* CALayer.swift in Sources */,
+				87B0D39F14038FF162ADA25A /* CGPath.swift in Sources */,
 				620758875CDFB7D9C6442A75 /* CaseIterable.swift in Sources */,
 				B5DDFD7AB905028533949838 /* Codable.swift in Sources */,
 				AF4170D746DA3C5F89010291 /* Data.swift in Sources */,
@@ -752,21 +755,20 @@
 				F66FB66FCA7B884DA64ADDBE /* Diff.swift in Sources */,
 				3E5C7662C80553ED51ED655B /* Diffing.swift in Sources */,
 				A9E8A45449313F3F4B1B4D3F /* Internal.swift in Sources */,
+				27E2E64971E40DB5E6E84BB6 /* NSBezierPath.swift in Sources */,
 				9A1B06446DC5BE00E017958D /* NSImage.swift in Sources */,
 				345FB3E29989E8B1DA53617A /* NSView.swift in Sources */,
-				431F526524633AAD00F256F4 /* SwiftUIView.swift in Sources */,
 				AEA906B0259465877DCED2AC /* NSViewController.swift in Sources */,
 				EC4E922DF51C6B2C024A3737 /* PlistEncoder.swift in Sources */,
 				06BA09CBE16A002564A3D098 /* SceneKit.swift in Sources */,
 				42BCD8FC5433734A7BD80486 /* SnapshotTestCase.swift in Sources */,
 				066041367BD8A6246C1F47F7 /* Snapshotting.swift in Sources */,
-				CA26E175242D0219008D08A0 /* CGPath.swift in Sources */,
 				941758F3457304C1ADDFF981 /* SpriteKit.swift in Sources */,
 				BA6099AF5DBC1D12C3066D14 /* String+SpecialCharacters.swift in Sources */,
 				1A0FB107B2820F9B33EFE2BB /* String.swift in Sources */,
-				CA26E171242D0219008D08A0 /* NSBezierPath.swift in Sources */,
+				7A113ED6F1950924A9012428 /* SwiftUIView.swift in Sources */,
+				4CF683A5FA0EDF2C6ABC8B10 /* UIBezierPath.swift in Sources */,
 				0C80A6C3FD6C62FDAC4123B3 /* UIImage.swift in Sources */,
-				CA26E179242D0219008D08A0 /* UIBezierPath.swift in Sources */,
 				6630A021629D13CD012A62FD /* UIView.swift in Sources */,
 				65ED4CF70D09F51DAD4C692A /* UIViewController.swift in Sources */,
 				7B9F0DFC589C66887A37F0FB /* URLRequest.swift in Sources */,
@@ -781,11 +783,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				76D4B4FEF767C6E546A261D1 /* InlineSnapshotTests.swift in Sources */,
+				8442C5AE49466F0F0CB6BD9C /* SnapshotTestingTests.swift in Sources */,
 				D5EED6FE1C8F85CE32392066 /* TestHelpers.swift in Sources */,
 				4D36F6FD7EC4C9D5EFEB1B54 /* WaitTests.swift in Sources */,
 				133A694B28958DA656061EC8 /* testCreateSnapshotEscapedNewlineLastLine.1.swift in Sources */,
 				19CAE304A06A92323E7C225C /* testCreateSnapshotMultiLine.1.swift in Sources */,
-				436E95562463421500DE7A44 /* SnapshotTestingTests.swift in Sources */,
 				E7A986FC4CE72492A5A2AFD7 /* testCreateSnapshotSingleLine.1.swift in Sources */,
 				F384274F4593F0BC4E8F94DC /* testCreateSnapshotWithExtendedDelimiter1.1.swift in Sources */,
 				DE888645B9529A2CCDE24580 /* testCreateSnapshotWithExtendedDelimiter2.1.swift in Sources */,
@@ -857,6 +859,7 @@
 				6C48EAD7C6D1441EE12F907B /* AssertSnapshot.swift in Sources */,
 				45FAA85BB7198113155FD27F /* Async.swift in Sources */,
 				E3E64AA7C25386DE50DB0995 /* CALayer.swift in Sources */,
+				DAAEB108C97963D4BF3C74E1 /* CGPath.swift in Sources */,
 				28106F59B265148F2CB38B5B /* CaseIterable.swift in Sources */,
 				5C7623E2C040A67AEF4BE329 /* Codable.swift in Sources */,
 				B30E8815010C2E79DD90B3C0 /* Data.swift in Sources */,
@@ -864,21 +867,20 @@
 				9068EBD3D0BB87B3CB76FFBA /* Diff.swift in Sources */,
 				6BCCCC6BAA13CE8DF37B92C7 /* Diffing.swift in Sources */,
 				4E2EC852FBB3BF0C7E9D8AB0 /* Internal.swift in Sources */,
+				B67546FC373990003C3C4D49 /* NSBezierPath.swift in Sources */,
 				CE53F597D12C921A3DA2E8B0 /* NSImage.swift in Sources */,
 				FE3FC1518791D7B6DD23D42A /* NSView.swift in Sources */,
-				431F526724633AAE00F256F4 /* SwiftUIView.swift in Sources */,
 				8C428A751E6342E2CE46E4CB /* NSViewController.swift in Sources */,
 				93F5DF248D854C8E353BCA25 /* PlistEncoder.swift in Sources */,
 				9BADD5EA602342F6EC050CDE /* SceneKit.swift in Sources */,
 				FEA0AF43D267C70A71A27427 /* SnapshotTestCase.swift in Sources */,
 				6839408A3D220CC5196456BC /* Snapshotting.swift in Sources */,
-				CA26E177242D0219008D08A0 /* CGPath.swift in Sources */,
 				D08F1EABB0BF974C05E74D8F /* SpriteKit.swift in Sources */,
 				10F68BDF40D553B893C6CB1E /* String+SpecialCharacters.swift in Sources */,
 				DC925700DE66F9134D3E47EA /* String.swift in Sources */,
-				CA26E173242D0219008D08A0 /* NSBezierPath.swift in Sources */,
+				E5EA11B0A1E1194E4285920E /* SwiftUIView.swift in Sources */,
+				5E7F4795AFED0D8D4E1D75A6 /* UIBezierPath.swift in Sources */,
 				B7C6F1A74C6D9DF70ACC52DB /* UIImage.swift in Sources */,
-				CA26E17B242D0219008D08A0 /* UIBezierPath.swift in Sources */,
 				436C10BC8313288D84733DC5 /* UIView.swift in Sources */,
 				969985906E267A3F203613F1 /* UIViewController.swift in Sources */,
 				573488A1374FE9CD280A0BEE /* URLRequest.swift in Sources */,
@@ -1010,10 +1012,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1058,10 +1057,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1140,10 +1136,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1170,10 +1163,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1200,10 +1190,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1309,10 +1296,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -37,7 +37,7 @@ extension Snapshotting where Value == CALayer, Format == UIImage {
   /// - Parameter precision: The percentage of pixels that must match.
   public static func image(precision: Float = 1, traits: UITraitCollection = .init())
     -> Snapshotting {
-      return SimplySnapshotting.image(precision: precision).pullback { layer in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).pullback { layer in
         renderer(bounds: layer.bounds, for: traits).image { ctx in
           layer.setNeedsLayout()
           layer.layoutIfNeeded()

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -40,7 +40,7 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
   ///
   /// - Parameter precision: The percentage of pixels that must match.
   public static func image(precision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision).pullback { path in
+    return SimplySnapshotting.image(precision: precision, scale: scale).pullback { path in
       let bounds = path.boundingBoxOfPath
       let format: UIGraphicsImageRendererFormat
       if #available(iOS 11.0, tvOS 11.0, *) {

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -53,7 +53,7 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
         config = .init(safeArea: .zero, size: size, traits: traits)
       }
 
-      return SimplySnapshotting.image(precision: precision).asyncPullback { view in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { view in
         var config = config
 
         let controller: UIViewController

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -11,7 +11,7 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   ///
   /// - Parameter precision: The percentage of pixels that must match.
   public static func image(precision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision).pullback { path in
+    return SimplySnapshotting.image(precision: precision, scale: scale).pullback { path in
       let bounds = path.bounds
       let format: UIGraphicsImageRendererFormat
       if #available(iOS 11.0, tvOS 11.0, *) {

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -4,16 +4,24 @@ import XCTest
 
 extension Diffing where Value == UIImage {
   /// A pixel-diffing strategy for UIImage's which requires a 100% match.
-  public static let image = Diffing.image(precision: 1)
+  public static let image = Diffing.image(precision: 1, scale: nil)
 
   /// A pixel-diffing strategy for UIImage that allows customizing how precise the matching must be.
   ///
   /// - Parameter precision: A value between 0 and 1, where 1 means the images must match 100% of their pixels.
+  /// - Parameter scale: Scale to use when loading the reference image from disk. If `nil` or the `UITraitCollection`s default value of `0.0`, the screens scale is used.
   /// - Returns: A new diffing strategy.
-  public static func image(precision: Float) -> Diffing {
+  public static func image(precision: Float, scale: CGFloat?) -> Diffing {
+    let imageScale: CGFloat
+    if let scale = scale, scale != 0.0 {
+      imageScale = scale
+    } else {
+        imageScale = UIScreen.main.scale
+    }
+
     return Diffing(
       toData: { $0.pngData() ?? emptyImage().pngData()! },
-      fromData: { UIImage(data: $0, scale: UIScreen.main.scale)! }
+      fromData: { UIImage(data: $0, scale: imageScale)! }
     ) { old, new in
       guard !compare(old, new, precision: precision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
@@ -48,16 +56,17 @@ extension Diffing where Value == UIImage {
 extension Snapshotting where Value == UIImage, Format == UIImage {
   /// A snapshot strategy for comparing images based on pixel equality.
   public static var image: Snapshotting {
-    return .image(precision: 1)
+    return .image(precision: 1, scale: nil)
   }
 
   /// A snapshot strategy for comparing images based on pixel equality.
   ///
   /// - Parameter precision: The percentage of pixels that must match.
-  public static func image(precision: Float) -> Snapshotting {
+  /// - Parameter scale: The scale of the reference image stored on disk.
+  public static func image(precision: Float, scale: CGFloat?) -> Snapshotting {
     return .init(
       pathExtension: "png",
-      diffing: .image(precision: precision)
+      diffing: .image(precision: precision, scale: scale)
     )
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -22,7 +22,7 @@ extension Snapshotting where Value == UIView, Format == UIImage {
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision).asyncPullback { view in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { view in
         snapshotView(
           config: .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init()),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -22,7 +22,7 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision).asyncPullback { viewController in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { viewController in
         snapshotView(
           config: size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) } ?? config,
           drawHierarchyInKeyWindow: false,
@@ -48,7 +48,7 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision).asyncPullback { viewController in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { viewController in
         snapshotView(
           config: .init(safeArea: .zero, size: size, traits: traits),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,


### PR DESCRIPTION
This PR resolves the issue described in #324 and partially in #243.

When overriding the scale of image snapshots by setting the `displayScale` property of the passed trait collection, failure diffs were not rendered correctly because the screens scale was used to interpret the snapshot stored on disk.

To resolve this issue, I introduced a new scale parameter to the image diffing strategies which falls back to the display scale if it's not set or the default *undefined* value `0.0` of the `UITraitCollection`.