### PR TITLE
Fix Xcode 12 Name Clash (#360)

### DIFF
--- a/Sources/SnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertInlineSnapshot.swift
@@ -69,7 +69,7 @@ public func _verifyInlineSnapshot<Value>(
   )
   -> String? {
 
-    let recording = recording || record
+    let recording = recording || isRecording
 
     do {
       let tookSnapshot = XCTestExpectation(description: "Took snapshot")

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -8,6 +8,14 @@ public var diffTool: String? = nil
 /// Whether or not to record all new references.
 public var isRecording = false
 
+/// Whether or not to record all new references.
+/// Due to a name clash in Xcode 12, this has been renamed to `isRecording`.
+@available(*, deprecated, renamed: "isRecording")
+public var record: Bool {
+  get { isRecording }
+  set { isRecording = newValue }
+}
+
 /// Asserts that a given value matches a reference on disk.
 ///
 /// - Parameters:

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -6,7 +6,7 @@ import XCTest
 public var diffTool: String? = nil
 
 /// Whether or not to record all new references.
-public var record = false
+public var isRecording = false
 
 /// Asserts that a given value matches a reference on disk.
 ///
@@ -165,7 +165,7 @@ public func verifySnapshot<Value, Format>(
   )
   -> String? {
 
-    let recording = recording || record
+    let recording = recording || isRecording
 
     do {
       let fileUrl = URL(fileURLWithPath: "\(file)", isDirectory: false)

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -1064,6 +1064,15 @@ final class SnapshotTestingTests: XCTestCase {
     assertSnapshot(matching: view, as: .image(layout: .device(config: .tv)), named: "device")
     #endif
   }
+
+  @available(*, deprecated)
+  func testIsRecordingProxy() {
+    SnapshotTesting.record = true
+    XCTAssertEqual(isRecording, true)
+
+    SnapshotTesting.record = false
+    XCTAssertEqual(isRecording, false)
+  }
 }
 
 #if os(iOS)

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -23,11 +23,11 @@ final class SnapshotTestingTests: XCTestCase {
   override func setUp() {
     super.setUp()
     diffTool = "ksdiff"
-//    record = true
+//    isRecording = true
   }
 
   override func tearDown() {
-    record = false
+    isRecording = false
     super.tearDown()
   }
 


### PR DESCRIPTION
Fixes #360.

Replaces the `record` boolean with `isRecording` due to a name clash with Xcode 12's [record(_ issue: XCTIssue)][1] function.

This contains a proxy boolean for compatibility with existing codebases that is marked deprecated.
One could argue that this should only be deprecated in iOS 14, macOS 11, etc., but I think it should be deprecated right away so users can move to the new `isRecording` now and don't have breaking changes when migrating to Xcode 12.

[1]: https://developer.apple.com/documentation/xcode-release-notes/xcode-12-beta-release-notes