### PR TITLE
Fix sharedApplication selector in sharedIfAvailable (#365)

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -666,7 +666,7 @@ private final class NavigationDelegate: NSObject, WKNavigationDelegate {
 #if os(iOS) || os(tvOS)
 extension UIApplication {
     static var sharedIfAvailable: UIApplication? {
-      let sharedSelector = NSSelectorFromString("shared")
+      let sharedSelector = NSSelectorFromString("sharedApplication")
       guard UIApplication.responds(to: sharedSelector) else {
         return nil
       }


### PR DESCRIPTION
Fixes #365 

The `sharedIfAvailable` property introduced in #352 should reference the Objective-C property name `sharedApplication`.

https://developer.apple.com/documentation/uikit/uiapplication/1622975-sharedapplication?language=objc