### PR TITLE
Make common logic available to third-party strategies for re-use

### DIFF
--- a/Sources/SnapshotTesting/Diffing.swift
+++ b/Sources/SnapshotTesting/Diffing.swift
@@ -31,4 +31,15 @@ public struct Diffing<Value> {
     self.fromData = fromData
     self.diff = diff
   }
+
+  internal init(
+    persist: Persisting<Value>,
+    diff: @escaping (_ lhs: Value, _ rhs: Value) -> (String, [XCTAttachment])?
+  ) {
+    self.init(
+      toData: persist.toData,
+      fromData: persist.fromData,
+      diff: diff
+    )
+  }
 }

--- a/Sources/SnapshotTesting/Formatting.swift
+++ b/Sources/SnapshotTesting/Formatting.swift
@@ -1,0 +1,85 @@
+import Foundation
+import XCTest
+
+/// A type representing the ability to transform a snapshottable value into a diffable format (like text or an image) for snapshot testing.
+public struct Formatting<Value, Format> {
+  /// How a value is transformed into a diffable snapshot format.
+  public var format: (Value) -> Async<Format>
+
+  /// Creates a formatting strategy.
+  ///
+  /// - Parameters:
+  ///   - asyncFormat: An asynchronous transform function from a value into a diffable snapshot format.
+  public init(
+    asyncFormat: @escaping (_ value: Value) -> Async<Format>
+    ) {
+    self.format = asyncFormat
+  }
+
+  /// Creates a formatting strategy.
+  ///
+  /// - Parameters:
+  ///   - pathExtension: The path extension applied to references saved to disk.
+  ///   - diffing: How to diff and convert the snapshot format to and from data.
+  ///   - snapshot: A transform function from a value into a diffable snapshot format.
+  public init(
+    format: @escaping (_ value: Value) -> Format
+    ) {
+    self.init {
+      Async(value: format($0))
+    }
+  }
+
+  /// Transforms a strategy on `Value`s into a strategy on `NewValue`s through a function `(NewValue) -> Value`.
+  ///
+  /// This is the most important operation for transforming existing strategies into new strategies. It allows you to transform a `Formatting<Value, Format>` into a `Formatting<NewValue, Format>` by pulling it back along a function `(NewValue) -> Value`. Notice that the function must go in the direction `(NewValue) -> Value` even though we are transforming in the other direction `(Formatting<Value, Format>) -> Formatting<NewValue, Format>`.
+  ///
+  /// A simple example of this is to `pullback` the snapshot strategy on `UIView`s to work on `UIViewController`s:
+  ///
+  ///     let strategy = Formatting<UIView, UIImage>.image.pullback { (vc: UIViewController) in
+  ///       return vc.view
+  ///     }
+  ///
+  /// Here we took the strategy that snapshots `UIView`s as `UIImage`s and pulled it back to work on `UIViewController`s by using the function `(UIViewController) -> UIView` that simply plucks the view out of the controller.
+  ///
+  /// Nearly every snapshot strategy provided in this library is a pullback of some base strategy, which shows just how important this operation is.
+  ///
+  /// - Parameters:
+  ///   - transform: A transform function from `NewValue` into `Value`.
+  public func pullback<NewValue>(_ transform: @escaping (_ otherValue: NewValue) -> Value) -> Formatting<NewValue, Format> {
+    return self.asyncPullback { newValue in Async(value: transform(newValue)) }
+  }
+
+  /// Transforms a strategy on `Value`s into a strategy on `NewValue`s through a function `(NewValue) -> Async<Value>`.
+  ///
+  /// See the documention of `pullback` for a full description of how pullbacks works. This operation differs from `pullback` in that it allows you to use a transformation `(NewValue) -> Async<Value>`, which is necessary when your transformation needs to perform some asynchronous work.
+  ///
+  /// - Parameters:
+  ///   - transform: A transform function from `NewValue` into `Async<Value>`.
+  public func asyncPullback<NewValue>(
+    _ transform: @escaping (_ otherValue: NewValue) -> Async<Value>
+  ) -> Formatting<NewValue, Format> {
+    return Formatting<NewValue, Format> { newValue in
+      return .init { callback in
+        transform(newValue).run { value in
+          self.format(value).run { format in
+            callback(format)
+          }
+        }
+      }
+    }
+  }
+
+  func callAsFunction(_ value: Value) -> Async<Format> {
+    self.format(value)
+  }
+}
+
+/// A snapshot strategy where the type being snapshot is also a diffable type.
+public typealias SimplyFormatting<Format> = Formatting<Format, Format>
+
+extension Formatting where Value == Format {
+  public init(pathExtension: String?, diffing: Diffing<Format>) {
+    self.init(format: { $0 })
+  }
+}

--- a/Sources/SnapshotTesting/Persisting.swift
+++ b/Sources/SnapshotTesting/Persisting.swift
@@ -1,0 +1,45 @@
+import Foundation
+import XCTest
+
+/// A type representing the ability to read/write a snapshottable value from/to data for snapshot testing.
+public struct Persisting<Value> {
+  /// Converts a value _to_ data.
+  public var toData: (Value) -> Data
+
+  /// Produces a value _from_ data.
+  public var fromData: (Data) -> Value
+
+  /// Creates a new `Persisting` on `Value`.
+  ///
+  /// - Parameters:
+  ///   - toData: A function used to convert a value _to_ data.
+  ///   - value: A value to convert into data.
+  ///   - fromData: A function used to produce a value _from_ data.
+  ///   - data: Data to convert into a value.
+  public init(
+    toData: @escaping (_ value: Value) -> Data,
+    fromData: @escaping (_ data: Data) -> Value
+  ) {
+    self.toData = toData
+    self.fromData = fromData
+  }
+
+  /// Transforms a strategy on `Value`s into a strategy on `NewValue`s through a function `(NewValue) -> Value`.
+  ///
+  /// - Parameters:
+  ///   - toValue: A transform function from `NewValue` into `Value`.
+  ///   - fromValue: A transform function from `Value` into `NewValue`.
+  public func pullback<NewValue>(
+    toValue: @escaping (_ value: NewValue) -> Value,
+    fromValue: @escaping (_ data: Value) -> NewValue
+  ) -> Persisting<NewValue> {
+    return Persisting<NewValue>(
+      toData: { newValue in
+        self.toData(toValue(newValue))
+      },
+      fromData: { data in
+        fromValue(self.fromData(data))
+      }
+    )
+  }
+}

--- a/Sources/SnapshotTesting/Snapshotting.swift
+++ b/Sources/SnapshotTesting/Snapshotting.swift
@@ -23,7 +23,7 @@ public struct Snapshotting<Value, Format> {
     pathExtension: String?,
     diffing: Diffing<Format>,
     asyncSnapshot: @escaping (_ value: Value) -> Async<Format>
-    ) {
+  ) {
     self.pathExtension = pathExtension
     self.diffing = diffing
     self.snapshot = asyncSnapshot
@@ -40,7 +40,7 @@ public struct Snapshotting<Value, Format> {
     pathExtension: String?,
     diffing: Diffing<Format>,
     snapshot: @escaping (_ value: Value) -> Format
-    ) {
+  ) {
     self.init(pathExtension: pathExtension, diffing: diffing) {
       Async(value: snapshot($0))
     }

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -3,7 +3,18 @@ import Foundation
 extension Snapshotting where Format == String {
   /// A snapshot strategy for comparing any structure based on a sanitized text dump.
   public static var dump: Snapshotting {
-    return SimplySnapshotting.lines.pullback { snap($0) }
+    return SimplySnapshotting.lines.asyncPullback(
+      Formatting.dump.format
+    )
+  }
+}
+
+extension Formatting where Format == String {
+  /// A format strategy for converting any structure to a sanitized text dump.
+  public static var dump: Formatting {
+    return Formatting(format: { any in
+      snap(any)
+    })
   }
 }
 

--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -11,7 +11,18 @@ extension Snapshotting where Value == CALayer, Format == NSImage {
   ///
   /// - Parameter precision: The percentage of pixels that must match.
   public static func image(precision: Float) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision).pullback { layer in
+    return SimplySnapshotting.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting.image.format
+    )
+  }
+}
+
+extension Formatting where Value == CALayer, Format == NSImage {
+  /// A format strategy for converting layers to images.
+  public static var image: Formatting {
+    return Formatting(format: { layer in
       let image = NSImage(size: layer.bounds.size)
       image.lockFocus()
       let context = NSGraphicsContext.current!.cgContext
@@ -20,9 +31,10 @@ extension Snapshotting where Value == CALayer, Format == NSImage {
       layer.render(in: context)
       image.unlockFocus()
       return image
-    }
+    })
   }
 }
+
 #elseif os(iOS) || os(tvOS)
 import UIKit
 
@@ -35,15 +47,25 @@ extension Snapshotting where Value == CALayer, Format == UIImage {
   /// A snapshot strategy for comparing layers based on pixel equality.
   ///
   /// - Parameter precision: The percentage of pixels that must match.
-  public static func image(precision: Float = 1, traits: UITraitCollection = .init())
-    -> Snapshotting {
-      return SimplySnapshotting.image(precision: precision).pullback { layer in
-        renderer(bounds: layer.bounds, for: traits).image { ctx in
-          layer.setNeedsLayout()
-          layer.layoutIfNeeded()
-          layer.render(in: ctx.cgContext)
-        }
+  public static func image(precision: Float = 1, traits: UITraitCollection = .init() ) -> Snapshotting {
+    return SimplySnapshotting.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting.image(traits: traits).format
+    )
+  }
+}
+
+extension Formatting where Value == CALayer, Format == UIImage {
+  /// A format strategy for converting layers to images.
+  public static func image(traits: UITraitCollection = .init()) -> Formatting {
+    Self(format: { layer in
+      renderer(bounds: layer.bounds, for: traits).image { ctx in
+        layer.setNeedsLayout()
+        layer.layoutIfNeeded()
+        layer.render(in: ctx.cgContext)
       }
+    })
   }
 }
 #endif

--- a/Sources/SnapshotTesting/Snapshotting/Codable.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Codable.swift
@@ -13,9 +13,9 @@ extension Snapshotting where Value: Encodable, Format == String {
   ///
   /// - Parameter encoder: A JSON encoder.
   public static func json(_ encoder: JSONEncoder) -> Snapshotting {
-    var snapshotting = SimplySnapshotting.lines.pullback { (encodable: Value) in
-      try! String(decoding: encoder.encode(encodable), as: UTF8.self)
-    }
+    var snapshotting = SimplySnapshotting.lines.asyncPullback(
+      Formatting<Value, Format>.json(encoder: encoder).format
+    )
     snapshotting.pathExtension = "json"
     return snapshotting
   }
@@ -31,10 +31,26 @@ extension Snapshotting where Value: Encodable, Format == String {
   ///
   /// - Parameter encoder: A property list encoder.
   public static func plist(_ encoder: PropertyListEncoder) -> Snapshotting {
-    var snapshotting = SimplySnapshotting.lines.pullback { (encodable: Value) in
-      try! String(decoding: encoder.encode(encodable), as: UTF8.self)
-    }
+    var snapshotting = SimplySnapshotting.lines.asyncPullback(
+      Formatting<Value, Format>.plist(encoder: encoder).format
+    )
     snapshotting.pathExtension = "plist"
     return snapshotting
+  }
+}
+
+extension Formatting where Value: Encodable, Format == String {
+  /// A format strategy for converting encodable structures to their JSON representation.
+  public static func json(encoder: JSONEncoder) -> Formatting {
+    Self(format: { encodable in
+      try! String(decoding: encoder.encode(encodable), as: UTF8.self)
+    })
+  }
+
+  /// A format strategy for converting encodable structures to their property list representation.
+  public static func plist(encoder: PropertyListEncoder) -> Formatting {
+    Self(format: { encodable in
+      try! String(decoding: encoder.encode(encodable), as: UTF8.self)
+    })
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/Data.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Data.swift
@@ -5,13 +5,22 @@ extension Snapshotting where Value == Data, Format == Data {
   public static var data: Snapshotting {
     return .init(
       pathExtension: nil,
-      diffing: .init(toData: { $0 }, fromData: { $0 }) { old, new in
+      diffing: .init(persist: Persisting.data) { old, new in
         guard old != new else { return nil }
         let message = old.count == new.count
           ? "Expected data to match"
           : "Expected \(new) to match \(old)"
         return (message, [])
       }
+    )
+  }
+}
+
+extension Persisting where Value == Data {
+  public static var data: Persisting {
+    return Persisting(
+      toData: { $0 },
+      fromData: { $0 }
     )
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/Description.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Description.swift
@@ -2,6 +2,17 @@ extension Snapshotting where Format == String {
   /// A snapshot strategy that captures a value's textual description from `String`'s `init(description:)`
   /// initializer.
   public static var description: Snapshotting {
-    return SimplySnapshotting.lines.pullback(String.init(describing:))
+    return SimplySnapshotting.lines.asyncPullback(
+      Formatting.description.format
+    )
+  }
+}
+
+extension Formatting where Format == String {
+  /// A format strategy for converting layers to images.
+  public static var description: Formatting {
+    Self(format: { value in
+        String(describing: value)
+    })
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -11,10 +11,7 @@ extension Diffing where Value == NSImage {
   /// - Parameter precision: A value between 0 and 1, where 1 means the images must match 100% of their pixels.
   /// - Returns: A new diffing strategy.
   public static func image(precision: Float) -> Diffing {
-    return .init(
-      toData: { NSImagePNGRepresentation($0)! },
-      fromData: { NSImage(data: $0)! }
-    ) { old, new in
+    return .init(persist: Persisting.image) { old, new in
       guard !compare(old, new, precision: precision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
       let message = new.size == old.size
@@ -44,6 +41,16 @@ extension Snapshotting where Value == NSImage, Format == NSImage {
     )
   }
 }
+
+extension Persisting where Value == NSImage {
+  public static var image: Persisting {
+    return Persisting(
+      toData: { NSImagePNGRepresentation($0)! },
+      fromData: { NSImage(data: $0)! }
+    )
+  }
+}
+
 
 private func NSImagePNGRepresentation(_ image: NSImage) -> Data? {
   guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else { return nil }

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -13,7 +13,16 @@ extension Snapshotting where Value == NSView, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   public static func image(precision: Float = 1, size: CGSize? = nil) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision).asyncPullback { view in
+    return SimplySnapshotting.image(
+      precision: precision
+    ).asyncPullback(Formatting.image(size: size).format)
+  }
+}
+
+extension Formatting where Value == NSView, Format == NSImage {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize? = nil) -> Formatting {
+    Self(asyncFormat: { view in
       let initialSize = view.frame.size
       if let size = size { view.frame.size = size }
       guard view.frame.width > 0, view.frame.height > 0 else {
@@ -30,7 +39,7 @@ extension Snapshotting where Value == NSView, Format == NSImage {
           view.frame.size = initialSize
         }
       }
-    }
+    })
   }
 }
 

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -13,14 +13,39 @@ extension Snapshotting where Value == NSViewController, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   public static func image(precision: Float = 1, size: CGSize? = nil) -> Snapshotting {
-    return Snapshotting<NSView, NSImage>.image(precision: precision, size: size).pullback { $0.view }
+    return Snapshotting<NSView, NSImage>.image(
+        precision: precision,
+        size: size
+    ).asyncPullback(
+      Formatting<NSViewController, NSView>.image.format
+    )
   }
 }
 
 extension Snapshotting where Value == NSViewController, Format == String {
   /// A snapshot strategy for comparing view controller views based on a recursive description of their properties and hierarchies.
   public static var recursiveDescription: Snapshotting {
-    return Snapshotting<NSView, String>.recursiveDescription.pullback { $0.view }
+    return Snapshotting<NSView, String>.recursiveDescription.asyncPullback(
+        Formatting<NSViewController, NSView>.image.format
+    )
+  }
+}
+
+extension Formatting where Value == NSViewController, Format == NSView {
+  /// A format strategy for converting layers to images.
+  public static var image: Formatting {
+    Self(format: { $0.view })
+  }
+}
+
+extension Formatting where Value == NSViewController, Format == NSImage {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize? = nil) -> Formatting {
+    Formatting<NSView, NSImage>.image(
+      size: size
+    ).asyncPullback(
+      Formatting<NSViewController, NSView>.image.format
+    )
   }
 }
 #endif

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -14,7 +14,24 @@ extension Snapshotting where Value == SCNScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: The size of the scene.
   public static func image(precision: Float = 1, size: CGSize) -> Snapshotting {
-    return .scnScene(precision: precision, size: size)
+    return Snapshotting<NSView, NSImage>.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting<SCNScene, NSView>.image(
+        size: size
+      ).format
+    )
+  }
+}
+
+extension Formatting where Value == SCNScene, Format == NSView {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize) -> Formatting {
+    Self(format: { scene in
+        let view = SCNView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
+        view.scene = scene
+        return view
+    })
   }
 }
 #elseif os(iOS) || os(tvOS)
@@ -25,18 +42,26 @@ extension Snapshotting where Value == SCNScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: The size of the scene.
   public static func image(precision: Float = 1, size: CGSize) -> Snapshotting {
-    return .scnScene(precision: precision, size: size)
+    return Snapshotting<UIView, UIImage>.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting<SCNScene, UIView>.image(
+        size: size
+      ).format
+    )
+  }
+}
+
+extension Formatting where Value == SCNScene, Format == UIView {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize) -> Formatting {
+    Self(format: { scene in
+        let view = SCNView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
+        view.scene = scene
+        return view
+    })
   }
 }
 #endif
 
-fileprivate extension Snapshotting where Value == SCNScene, Format == Image {
-  static func scnScene(precision: Float, size: CGSize) -> Snapshotting {
-    return Snapshotting<View, Image>.image(precision: precision).pullback { scene in
-      let view = SCNView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
-      view.scene = scene
-      return view
-    }
-  }
-}
 #endif

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -14,7 +14,24 @@ extension Snapshotting where Value == SKScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: The size of the scene.
   public static func image(precision: Float = 1, size: CGSize) -> Snapshotting {
-    return .skScene(precision: precision, size: size)
+    return Snapshotting<NSView, NSImage>.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting<SKScene, NSView>.image(
+        size: size
+      ).format
+    )
+  }
+}
+
+extension Formatting where Value == SKScene, Format == NSView {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize) -> Formatting {
+    Self(format: { scene in
+        let view = SKView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
+        view.presentScene(scene)
+        return view
+    })
   }
 }
 #elseif os(iOS) || os(tvOS)
@@ -25,18 +42,26 @@ extension Snapshotting where Value == SKScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - size: The size of the scene.
   public static func image(precision: Float = 1, size: CGSize) -> Snapshotting {
-    return .skScene(precision: precision, size: size)
+    return Snapshotting<UIView, UIImage>.image(
+      precision: precision
+    ).asyncPullback(
+      Formatting<SKScene, UIView>.image(
+        size: size
+      ).format
+    )
+  }
+}
+
+extension Formatting where Value == SKScene, Format == UIView {
+  /// A format strategy for converting layers to images.
+  public static func image(size: CGSize) -> Formatting {
+    Self(format: { scene in
+        let view = SKView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
+        view.presentScene(scene)
+        return view
+    })
   }
 }
 #endif
 
-fileprivate extension Snapshotting where Value == SKScene, Format == Image {
-  static func skScene(precision: Float, size: CGSize) -> Snapshotting {
-    return Snapshotting<View, Image>.image(precision: precision).pullback { scene in
-      let view = SKView(frame: .init(x: 0, y: 0, width: size.width, height: size.height))
-      view.presentScene(scene)
-      return view
-    }
-  }
-}
 #endif

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -15,19 +15,27 @@ extension Formatting where Value == String, Format == String {
 
 extension Diffing where Value == String {
   /// A line-diffing strategy for UTF-8 text.
-  public static let lines = Diffing(
-    toData: { Data($0.utf8) },
-    fromData: { String(decoding: $0, as: UTF8.self) }
-  ) { old, new in
-    guard old != new else { return nil }
-    let hunks = chunk(diff: SnapshotTesting.diff(
-      old.split(separator: "\n", omittingEmptySubsequences: false).map(String.init),
-      new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-    ))
-    let failure = hunks
-      .flatMap { [$0.patchMark] + $0.lines }
-      .joined(separator: "\n")
-    let attachment = XCTAttachment(data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
-    return (failure, [attachment])
+  public static var lines: Diffing {
+    return Diffing(persist: Persisting.string) { old, new in
+      guard old != new else { return nil }
+      let hunks = chunk(diff: SnapshotTesting.diff(
+        old.split(separator: "\n", omittingEmptySubsequences: false).map(String.init),
+        new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+      ))
+      let failure = hunks
+        .flatMap { [$0.patchMark] + $0.lines }
+        .joined(separator: "\n")
+      let attachment = XCTAttachment(data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
+      return (failure, [attachment])
+    }
+  }
+}
+
+extension Persisting where Value == String {
+  public static var string: Persisting {
+    return Persisting(
+        toData: { Data($0.utf8) },
+        fromData: { String(decoding: $0, as: UTF8.self) }
+    )
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -6,6 +6,13 @@ extension Snapshotting where Value == String, Format == String {
   public static let lines = Snapshotting(pathExtension: "txt", diffing: .lines)
 }
 
+extension Formatting where Value == String, Format == String {
+  /// A format strategy for converting strings to strings.
+  public static var lines: Formatting {
+    return Formatting(format: { $0 })
+  }
+}
+
 extension Diffing where Value == String {
   /// A line-diffing strategy for UTF-8 text.
   public static let lines = Diffing(

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -11,19 +11,30 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   ///
   /// - Parameter precision: The percentage of pixels that must match.
   public static func image(precision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision).pullback { path in
-      let bounds = path.bounds
-      let format: UIGraphicsImageRendererFormat
-      if #available(iOS 11.0, tvOS 11.0, *) {
-        format = UIGraphicsImageRendererFormat.preferred()
-      } else {
-        format = UIGraphicsImageRendererFormat.default()
-      }
-      format.scale = scale
-      return UIGraphicsImageRenderer(bounds: bounds, format: format).image { ctx in
-        path.fill()
-      }
-    }
+    return SimplySnapshotting.image(
+        precision: precision
+    ).asyncPullback(
+      Formatting.image(scale: scale).format
+    )
+  }
+}
+
+extension Formatting where Value == UIBezierPath, Format == UIImage {
+  /// A format strategy for converting strings to strings.
+  public static func image(scale: CGFloat = 1) ->  Formatting {
+    return Formatting(format: { path in
+        let bounds = path.bounds
+        let format: UIGraphicsImageRendererFormat
+        if #available(iOS 11.0, tvOS 11.0, *) {
+          format = UIGraphicsImageRendererFormat.preferred()
+        } else {
+          format = UIGraphicsImageRendererFormat.default()
+        }
+        format.scale = scale
+        return UIGraphicsImageRenderer(bounds: bounds, format: format).image { ctx in
+          path.fill()
+        }
+    })
   }
 }
 
@@ -31,16 +42,27 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
 extension Snapshotting where Value == UIBezierPath, Format == String {
   /// A snapshot strategy for comparing bezier paths based on pixel equality.
   public static var elementsDescription: Snapshotting {
-    Snapshotting<CGPath, String>.elementsDescription.pullback { path in path.cgPath }
+    return .elementsDescription()
   }
 
   /// A snapshot strategy for comparing bezier paths based on pixel equality.
   ///
   /// - Parameter numberFormatter: The number formatter used for formatting points.
-  public static func elementsDescription(numberFormatter: NumberFormatter) -> Snapshotting {
+  public static func elementsDescription(numberFormatter: NumberFormatter? = nil) -> Snapshotting {
     Snapshotting<CGPath, String>.elementsDescription(
       numberFormatter: numberFormatter
-    ).pullback { path in path.cgPath }
+    ).asyncPullback(
+      Formatting.path.format
+    )
+  }
+}
+
+extension Formatting where Value == UIBezierPath, Format == CGPath {
+  /// A format strategy for converting strings to strings.
+  public static var path: Formatting {
+    return Formatting(format: { path in
+      path.cgPath
+    })
   }
 }
 #endif

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -11,10 +11,7 @@ extension Diffing where Value == UIImage {
   /// - Parameter precision: A value between 0 and 1, where 1 means the images must match 100% of their pixels.
   /// - Returns: A new diffing strategy.
   public static func image(precision: Float) -> Diffing {
-    return Diffing(
-      toData: { $0.pngData() ?? emptyImage().pngData()! },
-      fromData: { UIImage(data: $0, scale: UIScreen.main.scale)! }
-    ) { old, new in
+    return Diffing(persist: Persisting.image) { old, new in
       guard !compare(old, new, precision: precision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
       let message = new.size == old.size
@@ -32,7 +29,16 @@ extension Diffing where Value == UIImage {
       )
     }
   }
-  
+}
+
+extension Persisting where Value == UIImage {
+  public static var image: Persisting {
+    return Persisting(
+      toData: { $0.pngData() ?? emptyImage().pngData()! },
+      fromData: { UIImage(data: $0, scale: UIScreen.main.scale)! }
+    )
+  }
+
   /// Used when the image size has no width or no height to generated the default empty image
   private static func emptyImage() -> UIImage {
     let label = UILabel(frame: CGRect(x: 0, y: 0, width: 400, height: 80))

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -33,7 +33,6 @@ extension Diffing where Value == UIImage {
     }
   }
   
-  
   /// Used when the image size has no width or no height to generated the default empty image
   private static func emptyImage() -> UIImage {
     let label = UILabel(frame: CGRect(x: 0, y: 0, width: 400, height: 80))


### PR DESCRIPTION
While **SnapshotTesting** already comes with quite a few batteries included, once you try to use it for types other than views there still are [plenty](https://github.com/pointfreeco/swift-snapshot-testing/pull/391) [of](https://github.com/pointfreeco/swift-snapshot-testing/pull/315) [desirable](https://github.com/pointfreeco/swift-snapshot-testing/pull/349) [types](https://github.com/pointfreeco/swift-snapshot-testing/pull/387) [and](https://github.com/pointfreeco/swift-snapshot-testing/pull/388) [strategies](https://github.com/pointfreeco/swift-snapshot-testing/pull/391) [missing](https://github.com/pointfreeco/swift-snapshot-testing/pull/393).

Fortunately Swift (and the overall design of **SnapshotTesting**) allows for implementing custom strategies without having to fork the framework itself.

Unfortunately however currently all the `snapshot`, `toData`, and `fromData` closures are defined inline, making them inaccessible for 3rd-party use in custom strategies.

Let's say one wanted to implement a custom snapshot strategy for `NSView` that's supposed to use the same "render to NSImage" approach, while comparing by histogram similarity, instead of pixel equality, then one would have to copy the code from the existing `Snapshotting.image(precision:size:)` function:

```swift
extension Snapshotting where Value == NSView, Format == NSImage {
    public static func image(precision: Float = 1, size: CGSize? = nil) -> Snapshotting {
    // ...
    }
}
```

… and paste it slightly modified (changing `SimplySnapshotting.image` to `SimplySnapshotting.histogram`):

```swift
extension Snapshotting where Value == NSView, Format == NSImage {
// ...

    public static func histogram(precision: Float = 1, size: CGSize? = nil) -> Snapshotting {
        return SimplySnapshotting.histogram(precision: precision).asyncPullback { view in
            let initialSize = view.frame.size
            if let size = size { view.frame.size = size }
                guard view.frame.width > 0, view.frame.height > 0 else {
                    fatalError("View not renderable to image at size \(view.frame.size)")
                }
                return view.snapshot ?? Async { callback in
                    addImagesForRenderedViews(view).sequence().run { views in
                    let bitmapRep = view.bitmapImageRepForCachingDisplay(in: view.bounds)!
                    view.cacheDisplay(in: view.bounds, to: bitmapRep)
                    let image = NSImage(size: view.bounds.size)
                    image.addRepresentation(bitmapRep)
                    callback(image)
                    views.forEach { $0.removeFromSuperview() }
                    view.frame.size = initialSize
                }
            }
        }
    }
}
```

Now we have two methods in two different projects that we want to stay in sync.

Not a good place to be in.

The alternative approach of upstreaming the custom strategy would have to benefit of being able to refactor by extracting both equivalent pullback closures into a single helper function, removing the redundancy.

A look at the current state of the **SnapshotTesting** project however shows 44 open issues and 25 open pull requests. As such, realistically speaking, a corresponding pull request inevitably would spend quite some time waiting for review and might even end up getting rejected. That's a lot of uncertainty and unpredictability, when you already had a hard time convincing management that you needed to invest time to improve a third-party testing framework, while you should have been working on features instead, yadda, yadda.

So how can we fix this? Or at least level the playing field enough to make writing third-party strategies less of a implementation and maintenance burden?

With upstreaming being the less applicable and inferior overall approach I would argue that being able to make (re-)use of the often convoluted and intricate snapshotting (as in `Value -> Format`) and persistence (as in `Format <-> Data`) logic in your custom strategies, without having to reinvent the wheel over and over again, would go a long way.

As such this PR moves the currently private and inlined closures into dedicated `Formatting`/`Persisting` types in (similar to how `Snapshotitng` and `Diffing` are used) and exposes them to third-parties.

This is accomplished without breaking the public API.