### PR TITLE
Update AccessibilitySnapshot plugin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ end
   
   - [GRDBSnapshotTesting](https://github.com/SebastianOsinski/GRDBSnapshotTesting) adds snapshot strategy for testing SQLite database migrations made with [GRDB](https://github.com/groue/GRDB.swift).
   
-  - [AccessibilitySnapshot+SnapshotTesting](https://github.com/Sherlouk/AccessibilitySnapshot-SnapshotTesting) adds [AccessibilitySnapshot](https://github.com/cashapp/AccessibilitySnapshot) support for SnapshotTesting.
+  - [AccessibilitySnapshot](https://github.com/cashapp/AccessibilitySnapshot) adds easy regression testing for iOS accessibility.
 
 Have you written your own SnapshotTesting plug-in? [Add it here](https://github.com/pointfreeco/swift-snapshot-testing/edit/master/README.md) and submit a pull request!
   


### PR DESCRIPTION
As of https://github.com/cashapp/AccessibilitySnapshot/pull/21 AccessibilitySnapshot now supports SnapshotTesting in the official repository using my code. Updating the link here to point people in the right direction.