### PR TITLE
Make CI work with Swift 5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test-linux:
 		--rm \
 		-v "$(PWD):$(PWD)" \
 		-w "$(PWD)" \
-		swift:5.2 \
+		swift:5.3 \
 		bash -c 'make test-swift'
 
 test-macos:
@@ -23,7 +23,6 @@ test-ios:
 
 test-swift:
 	swift test \
-		--enable-pubgrub-resolver \
 		--parallel
 
 test-tvos:


### PR DESCRIPTION
CI seems to not be working anymore this is an attempt to fix it.

Pubgrub resolver is now enabled by default https://github.com/apple/swift-package-manager/pull/2421.