### PR TITLE
Make snapshotView function public

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -715,7 +715,7 @@ func prepareView(
   return dispose
 }
 
-func snapshotView(
+public func snapshotView(
   config: ViewImageConfig,
   drawHierarchyInKeyWindow: Bool,
   traits: UITraitCollection,


### PR DESCRIPTION
The reason to make this function public is so that we can write custom image view snapshot strategies that are different from `.image`. For example then I could write a custom strategy that would accept additional theme parameter to the view controller used to host tested view:

```swift
  public static func image(
    drawHierarchyInKeyWindow: Bool = false,
    precision: Float = 1,
    size: CGSize? = nil,
    traits: UITraitCollection = .init(),
    theme: Theme
    )
    -> Snapshotting {

      return SimplySnapshotting.image(precision: precision).asyncPullback { view in
        snapshotView(
          config: .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init()),
          drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
          traits: traits,
          view: view,
          viewController: BaseViewController().with { $0.preferredTheme = theme }
        )
      }
  }
```