### PR TITLE
Add isFailOnNewRecording for automatic recording

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -8,6 +8,11 @@ public var diffTool: String? = nil
 /// Whether or not to record all new references.
 public var isRecording = false
 
+/// Whether or not to fail when a recording changes
+/// This should only be turned off when running swift-snapshot-testcase with an external screenshot tracking service
+/// such as Screenshotbot. Incorrectly turning this off can hide real regressions.
+public var isFailOnNewRecording = true
+
 /// Whether or not to record all new references.
 /// Due to a name clash in Xcode 12, this has been renamed to `isRecording`.
 @available(*, deprecated, renamed: "isRecording")
@@ -49,7 +54,10 @@ public func assertSnapshot<Value, Format>(
     line: line
   )
   guard let message = failure else { return }
-  XCTFail(message, file: file, line: line)
+
+  if (isFailOnNewRecording) {
+    XCTFail(message, file: file, line: line)
+  }
 }
 
 /// Asserts that a given value matches references on disk.
@@ -173,7 +181,7 @@ public func verifySnapshot<Value, Format>(
   )
   -> String? {
 
-    let recording = recording || isRecording
+    let recording = recording || isRecording || !isFailOnNewRecording
 
     do {
       let fileUrl = URL(fileURLWithPath: "\(file)", isDirectory: false)


### PR DESCRIPTION
I work on [Screenshotbot](https://screenshotbot.io), which is a screenshotbot/snapshot testing service, which automates all of the recording workflow. I'm also the original author of https://github.com/facebook/screenshot-tests-for-android, and previously built something very similar to Screenshotbot at Facebook.

With Screenshotbot, we would want to move the recording flow to CI. So developers shouldn't have to manually record screenshots. They should make the changes, push to CI/open a pull request, and the CI would automatically comment on the PR with whatever changes happened, (or if it's already merged, then sends a Jira/Asana/Github Issue task to the author).

But this requires that the tests don't fail when the snapshots change (because a screenshot change in this flow isn't a *failure*, it's just something that we send tasks for). And that's the feature I'm adding in this PR. It's a relatively straightforward change, but let me know if you need more information from me.