### PR TITLE
Speed up NSImage comparison

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -77,12 +77,17 @@ private func compare(_ old: NSImage, _ new: NSImage, precision: Float) -> Bool {
   let newRep = NSBitmapImageRep(cgImage: newerCgImage)
   var differentPixelCount = 0
   let pixelCount = oldRep.pixelsWide * oldRep.pixelsHigh
-  let threshold = 1 - precision
-  for x in 0..<oldRep.pixelsWide {
-    for y in 0..<oldRep.pixelsHigh {
-      if oldRep.colorAt(x: x, y: y) != newRep.colorAt(x: x, y: y) { differentPixelCount += 1 }
-      if Float(differentPixelCount) / Float(pixelCount) > threshold { return false}
+  let threshold = (1 - precision) * Float(pixelCount)
+  let p1: UnsafeMutablePointer<UInt8> = oldRep.bitmapData!
+  let p2: UnsafeMutablePointer<UInt8> = newRep.bitmapData!
+  for offset in 0 ..< pixelCount {
+    if p1[offset] != p2[offset]
+        || p1[offset + 1] != p2[offset + 1]
+        || p1[offset + 2] != p2[offset + 2]
+        || p1[offset + 3] != p2[offset + 3] {
+        differentPixelCount += 1
     }
+    if Float(differentPixelCount) > threshold { return false }
   }
   return true
 }


### PR DESCRIPTION
I've noticed that NSImage diffing is quite slow when using precision < 1 and large images. I guess that's mostly unavoidable but here's a little tweak that made it more than twice at fast in our case:

```
❯ swift compare.swift
false
compare1, precision 1    : 0.20623600482940674
true
compare1, precision 0.999: 5.742478966712952
false
compare2, precision 1    : 0.08092296123504639
true
compare2, precision 0.999: 2.4135000705718994
```

I'm attaching the test script and the two files I used below.

https://gist.github.com/finestructure/84b0b58b567e857b4f38c0e07882eecf

<img width="1200" alt="new" src="https://user-images.githubusercontent.com/65520/108834725-cf814380-75ce-11eb-81d0-4b943c3e350e.png">
<img width="1200" alt="orig" src="https://user-images.githubusercontent.com/65520/108834729-d0b27080-75ce-11eb-8855-118366f2e1da.png">

(BTW: the tiny three pixel diff we're seeing in those images are between an M1 and an Intel Mac with otherwise identical OS and Xcode versions 🤪)
