### PR TITLE
Added config parameter to UIView Snapshotting

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -15,6 +15,7 @@ extension Snapshotting where Value == UIView, Format == UIImage {
   ///   - size: A view size override.
   ///   - traits: A trait collection override.
   public static func image(
+    on config: ViewImageConfig? = nil,
     drawHierarchyInKeyWindow: Bool = false,
     precision: Float = 1,
     size: CGSize? = nil,
@@ -23,8 +24,14 @@ extension Snapshotting where Value == UIView, Format == UIImage {
     -> Snapshotting {
 
       return SimplySnapshotting.image(precision: precision).asyncPullback { view in
-        snapshotView(
-          config: .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init()),
+        let snapshotViewConfig: ViewImageConfig
+        if let config = config {
+            snapshotViewConfig = size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) } ?? config
+        } else {
+            snapshotViewConfig = .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init())
+        }
+        return snapshotView(
+          config: snapshotViewConfig,
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
           traits: traits,
           view: view,


### PR DESCRIPTION
It's possible to specify a device by using `.image(on: DEVICETYPE)` like in `assertSnapshot(matching: vc, as: .image(on: .iPhoneSe))`. However, this only works on a ViewController, not a view. 

This changeset adds the same option to views.