### PR TITLE
Ussue with compiling via Carthage. 

### DIFF
--- a/SnapshotTesting.xcodeproj/project.pbxproj
+++ b/SnapshotTesting.xcodeproj/project.pbxproj
@@ -646,8 +646,6 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 1020;
-				TargetAttributes = {
-				};
 			};
 			buildConfigurationList = D9A4BF45876C849A308801A2 /* Build configuration list for PBXProject "SnapshotTesting" */;
 			compatibilityVersion = "Xcode 10.0";
@@ -1017,7 +1015,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1065,7 +1066,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1116,6 +1120,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1146,7 +1151,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1175,7 +1183,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1204,7 +1215,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1256,6 +1270,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_TESTING_SEARCH_PATHS = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1313,7 +1328,10 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_BITCODE = NO;
 				ENABLE_TESTING_SEARCH_PATHS = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				INFOPLIST_FILE = Sources/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Hey, I had an issue with building snapshot testing via Carthage. 
Version 1.8.2
Xcode 12.5 (12E262) - Apple Swift version 5.4 (swiftlang-1205.0.26.9 clang-1205.0.19.55)
Carthage 0.37.0

```bash
# carthage update swift-snapshot-testing
*** Checking out swift-snapshot-testing at ""
*** xcodebuild output can be found in /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/carthage-xcodebuild.8cpxUM.log
*** Building scheme "SnapshotTesting_macOS" in SnapshotTesting.xcodeproj
Build Failed
	Task failed with exit code 65:
	/usr/bin/xcrun xcodebuild -project .../swift-snapshot-testing/SnapshotTesting.xcodeproj -scheme SnapshotTesting_macOS -configuration Release -derivedDataPath .../org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive VALIDATE_WORKSPACE=NO -archivePath /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/swift-snapshot-testing SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in .../swift-snapshot-testing)

This usually indicates that project itself failed to compile. Please check the xcodebuild log for more details: /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/carthage-xcodebuild.8cpxUM.log

```

```bash
/usr/bin/xcrun xcodebuild -project .../Carthage/Checkouts/swift-snapshot-testing/SnapshotTesting.xcodeproj -scheme SnapshotTesting_macOS -configuration Release -derivedDataPath /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive VALIDATE_WORKSPACE=NO -archivePath /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/swift-snapshot-testing SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO (launched in .../Carthage/Checkouts/swift-snapshot-testing)Command line invocation:
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project .../Carthage/Checkouts/swift-snapshot-testing/SnapshotTesting.xcodeproj -scheme SnapshotTesting_macOS -configuration Release -derivedDataPath /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6 ONLY_ACTIVE_ARCH=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES archive VALIDATE_WORKSPACE=NO -archivePath /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/swift-snapshot-testing SKIP_INSTALL=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=NO CLANG_ENABLE_CODE_COVERAGE=NO STRIP_INSTALLED_PRODUCT=NO

User defaults from command line:
    IDEArchivePathOverride = /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/swift-snapshot-testing
    IDEDerivedDataPathOverride = /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6
    IDEPackageSupportUseBuiltinSCM = YES

Build settings from command line:
    CARTHAGE = YES
    CLANG_ENABLE_CODE_COVERAGE = NO
    CODE_SIGN_IDENTITY = 
    CODE_SIGNING_REQUIRED = NO
    GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO
    ONLY_ACTIVE_ARCH = NO
    SKIP_INSTALL = YES
    STRIP_INSTALLED_PRODUCT = NO
    VALIDATE_WORKSPACE = NO

note: Using new build system
note: Building targets in parallel
note: Using codesigning identity override: 
note: Planning build
note: Analyzing workspace
note: Constructing build description
note: Build preparation complete
CreateBuildDirectory /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath
    cd /.../Carthage/Checkouts/swift-snapshot-testing/SnapshotTesting.xcodeproj
    builtin-create-build-directory /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath

...


CompileSwift normal x86_64 (in target 'SnapshotTesting_macOS' from project 'SnapshotTesting')
    cd /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Any.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Async.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CALayer.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CGPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CaseIterable.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Codable.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Data.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Description.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Diff.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Diffing.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/Internal.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSImage.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSViewController.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/PlistEncoder.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SceneKit.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/SnapshotTestCase.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/String+SpecialCharacters.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/String.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIImage.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIViewController.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/URLRequest.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/View.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Extensions/Wait.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/XCTAttachment.swift -supplementary-output-file-map /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/supplementaryOutputs-d579d1 -target x86_64-apple-macos10.10 -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -I /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -application-extension -g -module-cache-path /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/ModuleCache.noindex -swift-version 5 -enforce-exclusivity\=checked -O -serialize-debugging-options -Xcc -working-directory -Xcc /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-generated-files.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-own-target-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-project-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release/include -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources-normal/x86_64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources/x86_64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources -target-sdk-version 11.3 -module-name SnapshotTesting -num-threads 12 -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Any.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/AssertInlineSnapshot.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/AssertSnapshot.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Async.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/CALayer.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/CGPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/CaseIterable.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Codable.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Data.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Description.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Diff.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Diffing.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Internal.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/NSBezierPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/NSImage.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/NSView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/NSViewController.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/PlistEncoder.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/SceneKit.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/SnapshotTestCase.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Snapshotting.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/SpriteKit.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/String+SpecialCharacters.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/String.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/SwiftUIView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/UIBezierPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/UIImage.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/UIView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/UIViewController.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/URLRequest.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/View.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/Wait.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/x86_64/XCTAttachment.o
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift:43:3: error: cannot find 'XCTFail' in scope
  XCTFail(message, file: file, line: line)
  ^~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift:152:22: error: type 'XCTContext' has no member 'runActivity'
          XCTContext.runActivity(named: "Attached Failure Diff") { activity in
          ~~~~~~~~~~ ^~~~~~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift:44:3: error: cannot find 'XCTFail' in scope
  XCTFail(message, file: file, line: line)
  ^~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift:272:22: error: type 'XCTContext' has no member 'runActivity'
          XCTContext.runActivity(named: "Attached Failure Diff") { activity in
          ~~~~~~~~~~ ^~~~~~~~~~~

CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler (in target 'SnapshotTesting_macOS' from project 'SnapshotTesting')
    cd /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing
    export DEVELOPER_DIR\=/Applications/Xcode.app/Contents/Developer
    export SDKROOT\=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -incremental -module-name SnapshotTesting -O -whole-module-optimization -enforce-exclusivity\=checked @/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SnapshotTesting.SwiftFileList -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -target arm64-apple-macos10.10 -g -module-cache-path /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/ModuleCache.noindex -Xfrontend -serialize-debugging-options -application-extension -swift-version 5 -I /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -c -num-threads 12 -output-file-map /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SnapshotTesting_macOS-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SnapshotTesting.swiftmodule -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-generated-files.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-own-target-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-project-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release/include -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources-normal/arm64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources/arm64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SnapshotTesting-Swift.h -working-directory /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing
CompileSwift normal arm64 (in target 'SnapshotTesting_macOS' from project 'SnapshotTesting')
    cd /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Any.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Async.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CALayer.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CGPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/CaseIterable.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Codable.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Data.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/Description.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Diff.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Diffing.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/Internal.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSImage.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/NSViewController.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/PlistEncoder.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SceneKit.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/SnapshotTestCase.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/String+SpecialCharacters.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/String.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIImage.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIView.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/UIViewController.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Snapshotting/URLRequest.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/View.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Extensions/Wait.swift /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/Common/XCTAttachment.swift -supplementary-output-file-map /var/folders/td/xp49dlrn5j16hvfxxd5mhdc00000gn/T/supplementaryOutputs-5641a1 -target arm64-apple-macos10.10 -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk -I /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks -application-extension -g -module-cache-path /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/ModuleCache.noindex -swift-version 5 -enforce-exclusivity\=checked -O -serialize-debugging-options -Xcc -working-directory -Xcc /Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-generated-files.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-own-target-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/SnapshotTesting-project-headers.hmap -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/BuildProductsPath/Release/include -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources-normal/arm64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources/arm64 -Xcc -I/Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/DerivedSources -target-sdk-version 11.3 -module-name SnapshotTesting -num-threads 12 -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Any.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/AssertInlineSnapshot.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/AssertSnapshot.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Async.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/CALayer.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/CGPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/CaseIterable.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Codable.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Data.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Description.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Diff.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Diffing.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Internal.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/NSBezierPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/NSImage.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/NSView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/NSViewController.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/PlistEncoder.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SceneKit.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SnapshotTestCase.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Snapshotting.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SpriteKit.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/String+SpecialCharacters.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/String.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/SwiftUIView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/UIBezierPath.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/UIImage.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/UIView.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/UIViewController.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/URLRequest.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/View.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/Wait.o -o /Users/.../Library/Caches/org.carthage.CarthageKit/DerivedData/12.5_12E262/swift-snapshot-testing/641ad58daf62c4577dbcb23a80b1e437a459daf6/Build/Intermediates.noindex/ArchiveIntermediates/SnapshotTesting_macOS/IntermediateBuildFilesPath/SnapshotTesting.build/Release/SnapshotTesting_macOS.build/Objects-normal/arm64/XCTAttachment.o
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift:43:3: error: cannot find 'XCTFail' in scope
  XCTFail(message, file: file, line: line)
  ^~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertInlineSnapshot.swift:152:22: error: type 'XCTContext' has no member 'runActivity'
          XCTContext.runActivity(named: "Attached Failure Diff") { activity in
          ~~~~~~~~~~ ^~~~~~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift:44:3: error: cannot find 'XCTFail' in scope
  XCTFail(message, file: file, line: line)
  ^~~~~~~
/Users/.../git/iphone-app/Carthage/Checkouts/swift-snapshot-testing/Sources/SnapshotTesting/AssertSnapshot.swift:272:22: error: type 'XCTContext' has no member 'runActivity'
          XCTContext.runActivity(named: "Attached Failure Diff") { activity in
          ~~~~~~~~~~ ^~~~~~~~~~~

** ARCHIVE FAILED **


The following build commands failed:
	CompileSwift normal x86_64
	CompileSwiftSources normal x86_64 com.apple.xcode.tools.swift.compiler
	CompileSwift normal arm64
	CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler
(4 failures)
```

I fixed this by changing this to true.
```
ENABLE_TESTING_SEARCH_PATHS = YES;
```

I don't know if this is a dirty quick hack or the actual solution to this problem. 
Thanks :) 