### PR TITLE
Use the correct scale for the diff image

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -130,7 +130,8 @@ private func context(for cgImage: CGImage, bytesPerRow: Int, data: UnsafeMutable
 private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
   let width = max(old.size.width, new.size.width)
   let height = max(old.size.height, new.size.height)
-  UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), true, 0)
+  let scale = max(old.scale, new.scale)
+  UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), true, scale)
   new.draw(at: .zero)
   old.draw(at: .zero, blendMode: .difference, alpha: 1)
   let differenceImage = UIGraphicsGetImageFromCurrentImageContext()!


### PR DESCRIPTION
The `UIGraphicsBeginImageContextWithOptions` was setting the `scale` parameter to `0` which will default to the device's `UIDevice.main.scale`. This results in an incorrect difference image when taking snapshots for different devices. Instead, use the maximum scale of one of the passed in `UIImage`s.