### PR TITLE
Add option to disable counter suffixes

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -5,6 +5,9 @@ import XCTest
 ///     diffTool = "ksdiff"
 public var diffTool: String? = nil
 
+/// Whether or not to have snapshot tests add a counter suffix when the `named` parameter in `assertSnapshot()` is `nil`.
+public var addsCounterSuffixToEmptyTestName = true
+
 /// Whether or not to record all new references.
 public var isRecording = false
 
@@ -198,8 +201,15 @@ public func verifySnapshot<Value, Format>(
       }
 
       let testName = sanitizePathComponent(testName)
+      let pathComponent: String
+      if addsCounterSuffixToEmptyTestName && name == nil {
+        pathComponent = "\(testName).\(identifier)"
+      } else {
+        pathComponent = testName
+      }
+      
       let snapshotFileUrl = snapshotDirectoryUrl
-        .appendingPathComponent("\(testName).\(identifier)")
+        .appendingPathComponent(pathComponent)
         .appendingPathExtension(snapshotting.pathExtension ?? "")
       let fileManager = FileManager.default
       try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)


### PR DESCRIPTION
This addresses the issue here: https://github.com/pointfreeco/swift-snapshot-testing/issues/429

This allows users to disable the default behavior of snapshot creation, where a counter is added whenever a test doesn't specify a test name.

For tests that only validate one snapshot, adding a suffix to these tests seems excessive. For me, this would result in most test files looking like `MyViewControllerSnapshotTests/testLayout.1.png` and it would be nice to be able to disable this functionality when it's not desired to keep file names simpler: `MyViewControllerSnapshotTests/testLayout.png`
