### PR TITLE
Sort URL query items

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -46,12 +46,11 @@ extension Snapshotting where Value == URLRequest, Format == String {
     var components = ["curl"]
 
     // HTTP Method
-    if let httpMethod = request.httpMethod {
-      switch httpMethod {
-      case "GET": break
-      case "HEAD": components.append("--head")
-      default: components.append("--request \(httpMethod)")
-      }
+    let httpMethod = request.httpMethod!
+    switch httpMethod {
+    case "GET": break
+    case "HEAD": components.append("--head")
+    default: components.append("--request \(httpMethod)")```
     }
 
     // Headers

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -76,9 +76,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
     }
 
     // URL
-    if let url = request.url?.sortingQueryItems() {
-      components.append("\"\(url.absoluteString)\"")
-    }
+    components.append("\"\(request.url!.absoluteString)\"")
 
     return components.joined(separator: " \\\n\t")
   }

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
   /// - Parameter pretty: Attempts to pretty print the body of the request (supports JSON).
   public static func raw(pretty: Bool) -> Snapshotting {
     return SimplySnapshotting.lines.pullback { (request: URLRequest) in
-      let method = "\(request.httpMethod ?? "GET") \(request.url?.absoluteString ?? "(null)")"
+      let method = "\(request.httpMethod ?? "GET") \(request.url?.sortingQueryItems()?.absoluteString ?? "(null)")"
 
       let headers = (request.allHTTPHeaderFields ?? [:])
         .map { key, value in "\(key): \(value)" }
@@ -46,17 +46,18 @@ extension Snapshotting where Value == URLRequest, Format == String {
     var components = ["curl"]
 
     // HTTP Method
-    let httpMethod = request.httpMethod!
-    switch httpMethod {
-    case "GET": break
-    case "HEAD": components.append("--head")
-    default: components.append("--request \(httpMethod)")
+    if let httpMethod = request.httpMethod {
+      switch httpMethod {
+      case "GET": break
+      case "HEAD": components.append("--head")
+      default: components.append("--request \(httpMethod)")
+      }
     }
 
     // Headers
     if let headers = request.allHTTPHeaderFields {
       for field in headers.keys.sorted() where field != "Cookie" {
-        let escapedValue = headers[field]!.replacingOccurrences(of: "\"", with: "\\\"")
+        guard let escapedValue = headers[field]?.replacingOccurrences(of: "\"", with: "\\\"") else { continue }
         components.append("--header \"\(field): \(escapedValue)\"")
       }
     }
@@ -76,8 +77,20 @@ extension Snapshotting where Value == URLRequest, Format == String {
     }
 
     // URL
-    components.append("\"\(request.url!.absoluteString)\"")
+    if let url = request.url?.sortingQueryItems() {
+      components.append("\"\(url.absoluteString)\"")
+    }
 
     return components.joined(separator: " \\\n\t")
+  }
+}
+
+private extension URL {
+  func sortingQueryItems() -> URL? {
+    var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+    let sortedQueryItems = components?.queryItems?.sorted { $0.name < $1.name }
+    components?.queryItems = sortedQueryItems
+
+    return components?.url
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -50,7 +50,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
     switch httpMethod {
     case "GET": break
     case "HEAD": components.append("--head")
-    default: components.append("--request \(httpMethod)")```
+    default: components.append("--request \(httpMethod)")
     }
 
     // Headers

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -56,7 +56,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
     // Headers
     if let headers = request.allHTTPHeaderFields {
       for field in headers.keys.sorted() where field != "Cookie" {
-        guard let escapedValue = headers[field]?.replacingOccurrences(of: "\"", with: "\\\"") else { continue }
+        let escapedValue = headers[field]!.replacingOccurrences(of: "\"", with: "\\\"")
         components.append("--header \"\(field): \(escapedValue)\"")
       }
     }

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -76,7 +76,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
     }
 
     // URL
-    components.append("\"\(request.url!.absoluteString)\"")
+    components.append("\"\(request.url!.sortingQueryItems()!.absoluteString)\"")
 
     return components.joined(separator: " \\\n\t")
   }

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -918,6 +918,13 @@ final class SnapshotTestingTests: XCTestCase {
     assertSnapshot(matching: get, as: .raw, named: "get")
     assertSnapshot(matching: get, as: .curl, named: "get-curl")
 
+    var getWithQuery = URLRequest(url: URL(string: "https://www.pointfree.co?key_2=value_2&key_1=value_1&key_3=value_3")!)
+    getWithQuery.addValue("pf_session={}", forHTTPHeaderField: "Cookie")
+    getWithQuery.addValue("text/html", forHTTPHeaderField: "Accept")
+    getWithQuery.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    assertSnapshot(matching: getWithQuery, as: .raw, named: "get-with-query")
+    assertSnapshot(matching: getWithQuery, as: .curl, named: "get-with-query-curl")
+
     var post = URLRequest(url: URL(string: "https://www.pointfree.co/subscribe")!)
     post.httpMethod = "POST"
     post.addValue("pf_session={\"user_id\":\"0\"}", forHTTPHeaderField: "Cookie")

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-with-query-curl.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-with-query-curl.txt
@@ -1,0 +1,5 @@
+curl \
+	--header "Accept: text/html" \
+	--header "Content-Type: application/json" \
+	--cookie "pf_session={}" \
+	"https://www.pointfree.co?key_1=value_1&key_2=value_2&key_3=value_3"

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-with-query.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testURLRequest.get-with-query.txt
@@ -1,0 +1,4 @@
+GET https://www.pointfree.co?key_1=value_1&key_2=value_2&key_3=value_3
+Accept: text/html
+Content-Type: application/json
+Cookie: pf_session={}


### PR DESCRIPTION
I have an issue with snapshotting an `URLRequest` that contains multiple query items. When I'm building the `URLRequest` I'm using a `[String: Any]` dictionary for queries which results in random order of query items in the final `URLRequest`.