### PR TITLE
Introduce a way to treat snapshot recordings as artifacts

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -242,7 +242,19 @@ public func verifySnapshot<Value, Format>(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
-      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+      var additionalComponents: [String] = []
+      for component in snapshotFileUrl.pathComponents.reversed() {
+        if component != fileName {
+          additionalComponents.insert(component, at: 0)
+        } else {
+          break
+        }
+      }
+
+      var failedSnapshotFileUrl = artifactsSubUrl
+      for component in additionalComponents {
+        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+      }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
         let writeToUrl = treatRecordingsAsArtifacts ? failedSnapshotFileUrl : snapshotFileUrl

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -241,19 +241,27 @@ public func verifySnapshot<Value, Format>(
       let artifactsUrl = URL(
         fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
       )
-      let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
-      var additionalComponents: [String] = []
-      for component in snapshotFileUrl.pathComponents.reversed() {
-        if component != fileName {
-          additionalComponents.insert(component, at: 0)
-        } else {
-          break
-        }
-      }
+      var artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
 
-      var failedSnapshotFileUrl = artifactsSubUrl
-      for component in additionalComponents {
-        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+      var failedSnapshotFileUrl: URL
+      if treatRecordingsAsArtifacts {
+        var additionalComponents: [String] = []
+        for component in snapshotFileUrl.pathComponents.reversed() {
+          if component != fileName {
+            additionalComponents.insert(component, at: 0)
+          } else {
+            break
+          }
+        }
+
+        failedSnapshotFileUrl = artifactsSubUrl
+        for component in additionalComponents {
+          failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(component)
+          artifactsSubUrl = artifactsSubUrl.appendingPathComponent(component)
+        }
+        artifactsSubUrl = artifactsSubUrl.deletingLastPathComponent()
+      } else {
+        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -261,13 +261,14 @@ public func verifySnapshot<Value, Format>(
         }
         artifactsSubUrl = artifactsSubUrl.deletingLastPathComponent()
       } else {
-        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
+        failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent("failed")
+        failedSnapshotFileUrl = failedSnapshotFileUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)
       }
 
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
-        let writeToUrl = treatRecordingsAsArtifacts ? failedSnapshotFileUrl : snapshotFileUrl
+        let writeToUrl = failedSnapshotFileUrl
         try fileManager.createDirectory(
-          at: treatRecordingsAsArtifacts ? artifactsSubUrl : snapshotDirectoryUrl, withIntermediateDirectories: true
+          at: writeToUrl.deletingLastPathComponent(), withIntermediateDirectories: true
         )
 
         try snapshotting.diffing.toData(diffable).write(to: writeToUrl)
@@ -303,7 +304,7 @@ public func verifySnapshot<Value, Format>(
         return nil
       }
 
-      try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
+      try fileManager.createDirectory(at: failedSnapshotFileUrl.deletingLastPathComponent(), withIntermediateDirectories: true)
       try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
 
       if !attachments.isEmpty {


### PR DESCRIPTION
Our use case would prefer having the option of treating snapshot recordings (record mode as well as non-existent files) as artifacts, placing them in the same directory as failures. This PR introduces a new env option, TREAT_RECORDINGS_AS_ARTIFACTS to accomplish this goal. When set to `true`, new snapshot recordings will be placed in the same directory as SNAPSHOT_ARTIFACTS. When set to `false`, the intention is to have the same behavior as before.