### PR TITLE
Remove GLKView support

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -730,11 +730,6 @@ extension View {
       #endif
       return perform()
     }
-    #if (os(iOS) && !targetEnvironment(macCatalyst)) || os(tvOS)
-    if let glkView = self as? GLKView {
-      return Async(value: inWindow { glkView.snapshot })
-    }
-    #endif
     if let scnView = self as? SCNView {
       return Async(value: inWindow { scnView.snapshot() })
     } else if let skView = self as? SKView {


### PR DESCRIPTION
OpenGL types have been marked as deprecated starting with iOS 12, so if you compile SnapshotTesting with a minimum OS target version of iOS 12 or higher, you get the following compiler warning:

```
SnapshotTesting/Sources/SnapshotTesting/Common/View.swift:585:31: error: 'GLKView' was deprecated in iOS 12.0: OpenGLES API deprecated. (Define GLES_SILENCE_DEPRECATION to silence these warnings)
    if let glkView = self as? GLKView {
                              ^
```

Because Swift has no mechanism to silence deprecation warnings, I propose removing snapshotting support for `GLKView`.

Users of Snapshotting can still maintain support for snapshotting `GLKView`s with a custom snapshot strategy.