### PR TITLE
Leak when running with Host Application

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -941,6 +941,10 @@ private func add(traits: UITraitCollection, viewController: UIViewController, to
 
   return {
     rootViewController.beginAppearanceTransition(false, animated: false)
+    viewController.willMove(toParent: nil)
+    viewController.view.removeFromSuperview()
+    viewController.removeFromParent()
+    viewController.didMove(toParent: nil)
     rootViewController.endAppearanceTransition()
     window.rootViewController = nil
   }


### PR DESCRIPTION
Fixes https://github.com/pointfreeco/swift-snapshot-testing/issues/510

The cause of the leak is in the issue description 👆
The fix: By removing the view controller from its parent when the test finishes, no one retains the view controller, fixing the leak.

The same demo project that's in the issue using a branch with the fix: [SnapshotTestingLeakDemo-Fixed.zip](https://github.com/pointfreeco/swift-snapshot-testing/files/7128489/SnapshotTestingLeakDemo-Fixed.zip)


It would be great to have this automated, but it requires a new test target that uses a host application (and also a target for the host application). I'm open to doing that, but it's adding targets to the project, not sure if you want that.
