### PR TITLE
Added support for avoiding re-recording snapshots if there're no differences according to the matcher used.

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -6,7 +6,7 @@ import XCTest
 public var diffTool: String? = nil
 
 /// Whether or not to record all new references.
-public var isRecording = false
+public var isRecording = ProcessInfo.processInfo.environment["SNAPSHOT_RECORDING"] == "YES"
 
 /// Whether or not to record all new references.
 /// Due to a name clash in Xcode 12, this has been renamed to `isRecording`.

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -267,6 +267,9 @@ public func verifySnapshot<Value, Format>(
       #endif
 
       guard let (failure, attachments) = snapshotting.diffing.diff(reference, diffable) else {
+        if recording {
+          try fileManager.setAttributes([.modificationDate: Date()], ofItemAtPath: snapshotFileUrl.path)
+        }
         return nil
       }
       


### PR DESCRIPTION
This PR attempts to solve the problem of introducing unneeded changes in the snapshots for the projects that use "imprecise" matching, by avoiding recording a new version of a snapshot, if recording is enforced, and a new version of the snapshot does not differ from the original, according to the imprecise matcher used.

As an additional bonus, recording snapshots does not trigger test failures for versions that match the originals - it's now clearly seen from test results, what snapshots did not match the originals and were changed.