### PR TITLE
Allow clients to disable auto-record feature (#530)

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -5,6 +5,9 @@ import XCTest
 ///     diffTool = "ksdiff"
 public var diffTool: String? = nil
 
+/// Whether or not to automatically record snapshots when an existing file is not found.
+public var recordMissingSnapshots = true
+
 /// Whether or not to record all new references.
 public var isRecording = false
 
@@ -232,8 +235,15 @@ public func verifySnapshot<Value, Format>(
       guard var diffable = optionalDiffable else {
         return "Couldn't snapshot value"
       }
-      
+
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
+        if !recording && !recordMissingSnapshots {
+          return """
+                 No reference was found on disk, and `recordMissingSnapshots` is false.
+                 Did not record snapshot.
+                 """
+        }
+
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         return recording
           ? """


### PR DESCRIPTION
PR for issue #530.

Adds a global boolean to control whether or not the framework will auto-record missing snapshots.

Helpful for cases where CI/CD might attempt multiple retries, and auto-recording snapshots could cause false successes.