### PR TITLE
Programatic control over the artifacts directory

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -166,6 +166,7 @@ public func verifySnapshot<Value, Format>(
   named name: String? = nil,
   record recording: Bool = false,
   snapshotDirectory: String? = nil,
+  artifactsDirectory: String? = nil,
   timeout: TimeInterval = 5,
   file: StaticString = #file,
   testName: String = #function,
@@ -266,9 +267,14 @@ public func verifySnapshot<Value, Format>(
         return nil
       }
 
-      let artifactsUrl = URL(
-        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory(), isDirectory: true
-      )
+      let artifactsPath: String
+      if let artifactsDirectory = artifactsDirectory {
+        artifactsPath = artifactsDirectory
+      } else {
+        artifactsPath = ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"] ?? NSTemporaryDirectory()
+      }
+
+      let artifactsUrl = URL(fileURLWithPath: artifactsPath, isDirectory: true)
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
       try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
       let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(snapshotFileUrl.lastPathComponent)


### PR DESCRIPTION
### Motivation
I was aware of the environment variable but I believe it's preferable to have more control over it.
It's also more aligned wit the `snapshotDirectory` argument.

### Changes
Adds a new argument to `verifySnapshot<Value, Format>(...)` which defaults to `nil`.
When the argument is nil it keeps the old behaviour, otherwise it uses the passed value.


