### PR TITLE
Update XCTAttachment names to include test name and snapshot identifier

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -278,8 +278,12 @@ public func verifySnapshot<Value, Format>(
         #if !os(Linux)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
           XCTContext.runActivity(named: "Attached Failure Diff") { activity in
-            attachments.forEach {
-              activity.add($0)
+            attachments.forEach { attachment in
+              // Namespace the attachment name so it's easy to attribute back to this snapshot
+              if let attachmentName = attachment.name {
+                attachment.name = "\(testName)-\(identifier)-\(attachmentName)"
+              }
+              activity.add(attachment)
             }
           }
         }


### PR DESCRIPTION
I'm setting up snapshot testing for the [Lottie](https://github.com/airbnb/lottie-ios) project (airbnb/lottie-ios#1432). We're currently running snapshot tests using this library in CI. To help diagnose failures, we upload the resulting `.xcresult` archive and extract the `XCTAttachment` images.

Currently, all of the attachments have the same name (`reference`, `failure`, `difference`). This makes it challenging to browse through the list of attachment images:

<img width="636" alt="Screen Shot 2021-12-09 at 4 14 38 PM" src="https://user-images.githubusercontent.com/1811727/145613179-d92afba2-9057-48a9-86a3-3ef9e90ddd78.png">

This PR updates the `XCTAttachment` naming to include both the test name and snapshot identifier. This makes it much easier to browse through the list of attachment images:

<img width="915" alt="Screen Shot 2021-12-10 at 9 00 33 AM" src="https://user-images.githubusercontent.com/1811727/145613382-e38a1c59-752d-4a3e-b3f3-73107ae286da.png">

