### PR TITLE
Include snapshot name in failure message, if given

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -298,8 +298,16 @@ public func verifySnapshot<Value, Format>(
 
             SnapshotTesting.diffTool = "ksdiff"
         """
+
+      let failureMessage: String
+      if let name = name {
+        failureMessage = "Snapshot \"\(name)\" does not match reference."
+      } else {
+        failureMessage = "Snapshot does not match reference."
+      }
+
       return """
-      Snapshot does not match reference.
+      \(failureMessage)
 
       \(diffMessage)
 


### PR DESCRIPTION
I'm setting up snapshot testing for the [Lottie](https://github.com/airbnb/lottie-ios) project (airbnb/lottie-ios#1432). We're currently running snapshot tests using this library via the command line in CI.

Our tests are setup dynamically, so all run in the same `testLottieSnapshots` method but have a different `name` (the name of the file being snapshot).

Currently, the assertion messages only include the name of the test case. This makes it challenging to know which individual snapshot is failing:

```
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot does not match reference.
```

This PR updates the assertion failure message to include the snapshot name, if given. With this change, it's much easier to tell which individual snapshot is failing:

```
    ✖ testLottieSnapshots, failed - Snapshot "LottieLogo1 (0%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "LottieLogo1 (50%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "LottieLogo1 (100%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "Apostrophe (0%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "Apostrophe (50%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "Apostrophe (100%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "P (0%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "P (50%)" does not match reference.
    ✖ testLottieSnapshots, failed - Snapshot "P (100%)" does not match reference.