### PR TITLE
Added `Snapshotting.json` for `Any` value

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -7,6 +7,7 @@ extension Snapshotting where Format == String {
   }
 }
 
+@available(macOS 10.13, *)
 extension Snapshotting where Format == String {
   /// A snapshot strategy for comparing any structure based on their JSON representation.
   static var json: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -7,6 +7,23 @@ extension Snapshotting where Format == String {
   }
 }
 
+extension Snapshotting where Format == String {
+  /// A snapshot strategy for comparing any structure based on their JSON representation.
+  static var json: Snapshotting {
+    let options: JSONSerialization.WritingOptions = [
+      .prettyPrinted,
+      .sortedKeys
+    ]
+
+    var snapshotting = SimplySnapshotting.lines.pullback { (data: Value) in
+      try! String(decoding: JSONSerialization.data(withJSONObject: data,
+                                                   options: options), as: UTF8.self)
+    }
+    snapshotting.pathExtension = "json"
+    return snapshotting
+  }
+}
+
 private func snap<T>(_ value: T, name: String? = nil, indent: Int = 0) -> String {
   let indentation = String(repeating: " ", count: indent)
   let mirror = Mirror(reflecting: value)

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -10,7 +10,7 @@ extension Snapshotting where Format == String {
 @available(macOS 10.13, *)
 extension Snapshotting where Format == String {
   /// A snapshot strategy for comparing any structure based on their JSON representation.
-  static var json: Snapshotting {
+  public static var json: Snapshotting {
     let options: JSONSerialization.WritingOptions = [
       .prettyPrinted,
       .sortedKeys

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -43,6 +43,16 @@ final class SnapshotTestingTests: XCTestCase {
     """)
   }
 
+  func testAnyAsJson() throws {
+    struct User: Encodable { let id: Int, name: String, bio: String }
+    let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
+
+    let data = try JSONEncoder().encode(user)
+    let any = try JSONSerialization.jsonObject(with: data, options: [])
+
+    assertSnapshot(matching:any, as: .json)
+  }
+
   func testAnySnapshotStringConvertible() {
     assertSnapshot(matching: "a" as Character, as: .dump, named: "character")
     assertSnapshot(matching: Data("Hello, world!".utf8), as: .dump, named: "data")

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -51,7 +51,7 @@ final class SnapshotTestingTests: XCTestCase {
     let data = try JSONEncoder().encode(user)
     let any = try JSONSerialization.jsonObject(with: data, options: [])
 
-    assertSnapshot(matching:any, as: .json)
+    assertSnapshot(matching: any, as: .json)
   }
 
   func testAnySnapshotStringConvertible() {

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -43,6 +43,7 @@ final class SnapshotTestingTests: XCTestCase {
     """)
   }
 
+  @available(macOS 10.13, *)
   func testAnyAsJson() throws {
     struct User: Encodable { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testAnyAsJson.1.json
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testAnyAsJson.1.json
@@ -1,0 +1,5 @@
+{
+  "bio" : "Blobbed around the world.",
+  "id" : 1,
+  "name" : "Blobby"
+}


### PR DESCRIPTION
Currently the only way to snapshot `Any` value is using `dump`. However, the format isn't always as readable as it could be.
For data that can be encoded in JSON, this new overload provides a much more readable output.
