### PR TITLE
Fixes display scaling bug

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -52,7 +52,7 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
         snapshotView(
           config: .init(safeArea: .zero, size: size, traits: traits),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
-          traits: .init(),
+          traits: traits,
           view: viewController.view,
           viewController: viewController
         )


### PR DESCRIPTION
Noticed an issue where images would be saved at different scaled resolutions even when a display scale was specified (ie: `.image(traits: .init(displayScale: 3.0))`). This fixes this issue by passing along the traits parameter passed into the image function.