### PR TITLE
Fix tvOS, CocoaPods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
     strategy:
       matrix:
         xcode:
-          - "11.7"   # Swift 5.2
           - "12.4"   # Swift 5.3
           - "12.5.1" # Swift 5.4
           - "13.0"   # Swift 5.5

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,5 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
+
 import Foundation
 import PackageDescription
 
@@ -7,7 +8,8 @@ let package = Package(
   platforms: [
     .iOS(.v11),
     .macOS(.v10_10),
-    .tvOS(.v10)
+    .tvOS(.v11),
+    .watchOS(.v7),
   ],
   products: [
     .library(
@@ -15,12 +17,8 @@ let package = Package(
       targets: ["SnapshotTesting"]),
   ],
   targets: [
-    .target(
-      name: "SnapshotTesting",
-      dependencies: []),
-    .testTarget(
-      name: "SnapshotTestingTests",
-      dependencies: ["SnapshotTesting"]),
+    .target(name: "SnapshotTesting"),
+    .testTarget(name: "SnapshotTestingTests", dependencies: ["SnapshotTesting"]),
   ]
 )
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # 📸 SnapshotTesting
 
-[![Swift 5.1](https://img.shields.io/badge/swift-5.1-ED523F.svg?style=flat)](https://swift.org/download/)
 [![CI](https://github.com/pointfreeco/swift-snapshot-testing/workflows/CI/badge.svg)](https://actions-badge.atrox.dev/pointfreeco/swift-snapshot-testing/goto)
-[![@pointfreeco](https://img.shields.io/badge/contact-@pointfreeco-5AA9E7.svg?style=flat)](https://twitter.com/pointfreeco)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fpointfreeco%2Fswift-snapshot-testing%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing)
+[![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fpointfreeco%2Fswift-snapshot-testing%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing)
 
 Delightful Swift snapshot testing.
 

--- a/SnapshotTesting.podspec
+++ b/SnapshotTesting.podspec
@@ -28,7 +28,8 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = "11.0"
   s.osx.deployment_target = "10.10"
-  s.tvos.deployment_target = "10.0"
+  s.tvos.deployment_target = "11.0"
+  s.watchos.deployment_target = "7.4"
 
   s.frameworks = "XCTest"
   s.pod_target_xcconfig = { 'ENABLE_BITCODE' => 'NO' }


### PR DESCRIPTION
#552 broke tvOS support, which I noticed when running `pod lint`. I think we should probably drop CocoaPods and Carthage support eventually, but I also suppose folks rely on it more with this repo than other projects of ours.