### PR TITLE
Restore first responder after cleaning up UI hierarchy

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -935,6 +935,9 @@ private func add(traits: UITraitCollection, viewController: UIViewController, to
   viewController.view.layoutIfNeeded()
 
   return {
+    let originalFirstResponder = findFirstResponderRecursively(in: window)
+    defer { originalFirstResponder?.becomeFirstResponder() }
+
     rootViewController.beginAppearanceTransition(false, animated: false)
     viewController.willMove(toParent: nil)
     viewController.view.removeFromSuperview()
@@ -943,6 +946,18 @@ private func add(traits: UITraitCollection, viewController: UIViewController, to
     rootViewController.endAppearanceTransition()
     window.rootViewController = nil
   }
+}
+
+private func findFirstResponderRecursively(in view: UIView) -> UIView? {
+    for subView in view.subviews {
+        if subView.isFirstResponder {
+            return subView
+        }
+        if let recursiveSubView = findFirstResponderRecursively(in: subView) {
+            return recursiveSubView
+        }
+    }
+    return nil
 }
 
 private func getKeyWindow() -> UIWindow? {


### PR DESCRIPTION
This change fixes the following case:

- `UITextField` (or `UITextView`) is a first responder
- snapshot test runs
- `UITextField` is no more the first responder

The fix is particularly useful when the same view is passed to
two snapshot tests one after another. Say, the first snapshot test is
a plain UI check, and the second one is an accessibility or
layout test.