### PR TITLE
Include watchOS 4.0 in @available check

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -7,7 +7,7 @@ extension Snapshotting where Format == String {
   }
 }
 
-@available(macOS 10.13, *)
+@available(macOS 10.13, watchOS 4.0, *)
 extension Snapshotting where Format == String {
   /// A snapshot strategy for comparing any structure based on their JSON representation.
   public static var json: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/Codable.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Codable.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Snapshotting where Value: Encodable, Format == String {
   /// A snapshot strategy for comparing encodable structures based on their JSON representation.
-  @available(iOS 11.0, macOS 10.13, tvOS 11.0, *)
+  @available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)
   public static var json: Snapshotting {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -20,7 +20,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
 
       let body: [String]
       do {
-        if pretty, #available(iOS 11.0, macOS 10.13, tvOS 11.0, *) {
+        if pretty, #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
           body = try request.httpBody
             .map { try JSONSerialization.jsonObject(with: $0, options: []) }
             .map { try JSONSerialization.data(withJSONObject: $0, options: [.prettyPrinted, .sortedKeys]) }


### PR DESCRIPTION
Include watchOS in the availability check for `sortedKeys` allowing the library to compile under watchOS. 

This wouldn’t normally be necessary given that watchOS snapshots are not currently supported. 

However Xcode seems to try and compile test targets when generating SwiftUI previews and so those targeting Apple Watch weren’t rendering. 

This was making it difficult to work with SwiftUI previews inside modules containing views intended for both phone and watch platforms.

