### PR TITLE
Add support for tests executed repeatedly

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -173,6 +173,7 @@ public func verifySnapshot<Value, Format>(
   )
   -> String? {
 
+    CleanCounterBetweenTestCases.registerIfNeeded()
     let recording = recording || isRecording
 
     do {
@@ -327,4 +328,25 @@ func sanitizePathComponent(_ string: String) -> String {
   return string
     .replacingOccurrences(of: "\\W+", with: "-", options: .regularExpression)
     .replacingOccurrences(of: "^-|-$", with: "", options: .regularExpression)
+}
+
+// We need to clean counter between tests executions in order to support test-iterations.
+private class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
+    private static var registered = false
+    private static var registerQueue = DispatchQueue(label: "co.pointfree.SnapshotTesting.testObserver")
+
+    static func registerIfNeeded() {
+      registerQueue.sync {
+        if !registered {
+          registered = true
+          XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
+        }
+      }
+    }
+
+    func testCaseDidFinish(_ testCase: XCTestCase) {
+      counterQueue.sync {
+        counterMap = [:]
+      }
+    }
 }


### PR DESCRIPTION
### Motivation
`Xcode 13` introduced new parameters to `xcodebuild` that allow to run tests repeatedly ([wwdc talk](https://developer.apple.com/videos/play/wwdc2021/10296/)).
Unfortunately `SnapshotTesting` doesn't handle such situation in a correct way. 

### Proposal
We can use `XCTestObservation` in order to clean counter map between different test cases. 

### Resolved issues
Closes #577 