### PR TITLE
Attach recorded snapshot

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -235,6 +235,15 @@ public func verifySnapshot<Value, Format>(
       
       guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
+        #if !os(Linux) && !os(Windows)
+        if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
+          XCTContext.runActivity(named: "Attached Recorded Snapshot") { activity in
+            let attachment = XCTAttachment(contentsOfFile: snapshotFileUrl)
+            activity.add(attachment)
+          }
+        }
+        #endif
+
         return recording
           ? """
             Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.


### PR DESCRIPTION
The library already attaches failed snapshots using `XCTAttachment`. 

A nice extra would be to attach in case of newly recorded snapshots as well, since some developers are already used to going to the test results screen to inspect failed snapshots - now they can do that for new ones as well.

<img width="500" alt="Captura de Tela 2022-03-24 às 9 22 36 AM" src="https://user-images.githubusercontent.com/833072/159963738-44ede8d4-1519-408d-8650-ea15542700cc.png">
