### PR TITLE
Improve warning about view snapshot discrepancies

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ assertSnapshot(matching: vc, as: .image(on: .iPadMini(.portrait)))
 assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPadMini(.portrait)))
 ```
 
-> ⚠️ Warning: Snapshots must be compared using a simulator with the same OS, device gamut, and scale as the simulator that originally took the reference to avoid discrepancies between images.
+> ⚠️ Warning: Snapshots must be compared using the exact same simulator that originally took the reference to avoid discrepancies between images.
 
 Better yet, SnapshotTesting isn't limited to views and view controllers! There are [a number of available snapshot strategies](Documentation/Available-Snapshot-Strategies.md) to choose from.
 


### PR DESCRIPTION
I think it's better to be conservative, as the list of variables that can cause discrepancies is incomplete and unlikely to ever be exhaustive.

Other things that seem to cause differences:

* The architecture of the Mac running the simulator causing subtle "sub" pixel differences
* Optical font sizing adjustments that either don't respect the `displayScale` UI trait or deliberately ignore it because it's truly driven by the device display's points per inch (a product of the display's scale and pixels per inch)
* Changes to system fonts between iOS versions (lose fit, but added to emphasize the need for a snapshot strategy to be run on multiple devices, unless only one iOS version is targeted)

I think a broad caution is more prudent than extending the warning to include more device characteristics, as even if that list could be complete now, it would be very hard to track.