### PR TITLE
Introduce a comparison strategy as a parameter

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -32,12 +32,13 @@ extension Snapshotting where Value == CALayer, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing layers based on pixel equality.
+  /// A snapshot strategy for comparing layers based on the selected comparison strategy.
   ///
   /// - Parameter precision: The percentage of pixels that must match.
-  public static func image(precision: Float = 1, traits: UITraitCollection = .init())
+  /// - Parameter comparisonStrategy: A strategy for comparing snapshots with each other.
+  public static func image(precision: Float = 1, traits: UITraitCollection = .init(), comparisonStrategy: ComparisonStrategy = .equality)
     -> Snapshotting {
-      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).pullback { layer in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale, comparisonStrategy: comparisonStrategy).pullback { layer in
         renderer(bounds: layer.bounds, for: traits).image { ctx in
           layer.setNeedsLayout()
           layer.layoutIfNeeded()

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -36,11 +36,12 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing bezier paths based on pixel equality.
+  /// A snapshot strategy for comparing bezier paths based on the selected comparison strategy.
   ///
   /// - Parameter precision: The percentage of pixels that must match.
-  public static func image(precision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision, scale: scale).pullback { path in
+  /// - Parameter comparisonStrategy: A strategy for comparing snapshots with each other.
+  public static func image(precision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill, comparisonStrategy: ComparisonStrategy = .equality) -> Snapshotting {
+    return SimplySnapshotting.image(precision: precision, scale: scale, comparisonStrategy: comparisonStrategy).pullback { path in
       let bounds = path.boundingBoxOfPath
       let format: UIGraphicsImageRendererFormat
       if #available(iOS 11.0, tvOS 11.0, *) {

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -23,18 +23,20 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.
+  /// A snapshot strategy for comparing SwiftUI Views based on the selected comparison strategy.
   ///
   /// - Parameters:
   ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your tests and will _not_ work for framework test targets.
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   ///   - traits: A trait collection override.
+  ///   - comparisonStrategy: A strategy for comparing snapshots with each other.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
     precision: Float = 1,
     layout: SwiftUISnapshotLayout = .sizeThatFits,
-    traits: UITraitCollection = .init()
+    traits: UITraitCollection = .init(),
+    comparisonStrategy: ComparisonStrategy = .equality
     )
     -> Snapshotting {
       let config: ViewImageConfig
@@ -51,7 +53,7 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
         config = .init(safeArea: .zero, size: size, traits: traits)
       }
 
-      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { view in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale, comparisonStrategy: comparisonStrategy).asyncPullback { view in
         var config = config
 
         let controller: UIViewController

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -7,11 +7,12 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing bezier paths based on pixel equality.
+  /// A snapshot strategy for comparing bezier paths based on the selected comparison strategy.
   ///
   /// - Parameter precision: The percentage of pixels that must match.
-  public static func image(precision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
-    return SimplySnapshotting.image(precision: precision, scale: scale).pullback { path in
+  /// - Parameter comparisonStrategy: A strategy for comparing snapshots with each other.
+  public static func image(precision: Float = 1, scale: CGFloat = 1, comparisonStrategy: ComparisonStrategy = .equality) -> Snapshotting {
+    return SimplySnapshotting.image(precision: precision, scale: scale, comparisonStrategy: comparisonStrategy).pullback { path in
       let bounds = path.bounds
       let format: UIGraphicsImageRendererFormat
       if #available(iOS 11.0, tvOS 11.0, *) {

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -7,22 +7,24 @@ extension Snapshotting where Value == UIView, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing views based on pixel equality.
+  /// A snapshot strategy for comparing views based on the selected comparison strategy.
   ///
   /// - Parameters:
   ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your tests and will _not_ work for framework test targets.
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   ///   - traits: A trait collection override.
+  ///   - comparisonStrategy: A strategy for comparing snapshots with each other.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
     precision: Float = 1,
     size: CGSize? = nil,
-    traits: UITraitCollection = .init()
+    traits: UITraitCollection = .init(),
+    comparisonStrategy: ComparisonStrategy = .equality
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { view in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale, comparisonStrategy: comparisonStrategy).asyncPullback { view in
         snapshotView(
           config: .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init()),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -7,22 +7,24 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
     return .image()
   }
 
-  /// A snapshot strategy for comparing view controller views based on pixel equality.
+  /// A snapshot strategy for comparing view controller views based on the selected comparison strategy.
   ///
   /// - Parameters:
   ///   - config: A set of device configuration settings.
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   ///   - traits: A trait collection override.
+  ///   - comparisonStrategy: A strategy for comparing snapshots with each other.
   public static func image(
     on config: ViewImageConfig,
     precision: Float = 1,
     size: CGSize? = nil,
-    traits: UITraitCollection = .init()
+    traits: UITraitCollection = .init(),
+    comparisonStrategy: ComparisonStrategy = .equality
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { viewController in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale, comparisonStrategy: comparisonStrategy).asyncPullback { viewController in
         snapshotView(
           config: size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) } ?? config,
           drawHierarchyInKeyWindow: false,
@@ -33,22 +35,24 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
       }
   }
 
-  /// A snapshot strategy for comparing view controller views based on pixel equality.
+  /// A snapshot strategy for comparing view controller views based on the selected comparison strategy.
   ///
   /// - Parameters:
   ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your tests and will _not_ work for framework test targets.
   ///   - precision: The percentage of pixels that must match.
   ///   - size: A view size override.
   ///   - traits: A trait collection override.
+  ///   - comparisonStrategy: A strategy for comparing snapshots with each other.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
     precision: Float = 1,
     size: CGSize? = nil,
-    traits: UITraitCollection = .init()
+    traits: UITraitCollection = .init(),
+    comparisonStrategy: ComparisonStrategy = .equality
     )
     -> Snapshotting {
 
-      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale).asyncPullback { viewController in
+      return SimplySnapshotting.image(precision: precision, scale: traits.displayScale, comparisonStrategy: comparisonStrategy).asyncPullback { viewController in
         snapshotView(
           config: .init(safeArea: .zero, size: size, traits: traits),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,


### PR DESCRIPTION
**Problem**
Recently we discovered that sometimes Intel and M1 machines may produce slightly different snapshots. The difference is so small that it's not possible to recognize it with a human eye. But our CI finds such snapshots not equal to reference.

**Solution**
Approaching this issue we decided to change an algorithm taking into account not only how many pixels are different from each other, but also how much they are different.

Currently existing algorithm for calculating a snapshot difference:

```
var differentBytesCount = 0
allBytes.enumerate { oldByte, newByte in
    // If the bytes are not equal then difference is increased by 1. 
    if oldByte != newByte {
        differentBytesCount += 1
    }
}
```

New heuristics showed good results in our experiments:
```
var differentBytesCount = 0
allBytes.enumerate { oldByte, newByte in
    // If the bytes are not equal then difference is increased by
    // the value from [0;1] depending on how much is the difference. 
    differentBytesCount += abs(newByte - oldByte) / 255
}
```