### PR TITLE
Fixing wkWebView.takeSnapshot with Xcode 14

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -755,7 +755,11 @@ extension View {
                 callback(Image())
                 return
               }
-              wkWebView.takeSnapshot(with: nil) { image, _ in
+              let configuaration = WKSnapshotConfiguration()
+              if #available(iOS 13, *) {
+                configuaration.afterScreenUpdates = false
+              }
+              wkWebView.takeSnapshot(with: configuaration) { image, _ in
                 callback(image!)
               }
             }


### PR DESCRIPTION
Today the lib is crashing with Xcode 14 and snapshoting WKWebviews.

This will fix this issue: https://github.com/pointfreeco/swift-snapshot-testing/issues/625