### PR TITLE
Include failure reason when snapshot comparisons fail

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -1,5 +1,4 @@
 #if os(iOS) || os(tvOS)
-import CoreImage.CIFilterBuiltins
 import UIKit
 import XCTest
 
@@ -26,11 +25,8 @@ extension Diffing where Value == UIImage {
       toData: { $0.pngData() ?? emptyImage().pngData()! },
       fromData: { UIImage(data: $0, scale: imageScale)! }
     ) { old, new in
-      guard !compare(old, new, precision: precision, perceptualPrecision: perceptualPrecision) else { return nil }
+      guard let message = compare(old, new, precision: precision, perceptualPrecision: perceptualPrecision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
-      let message = new.size == old.size
-        ? "Newly-taken snapshot does not match reference."
-        : "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
       let oldAttachment = XCTAttachment(image: old)
       oldAttachment.name = "reference"
       let newAttachment = XCTAttachment(image: new)
@@ -81,76 +77,62 @@ private let imageContextColorSpace = CGColorSpace(name: CGColorSpace.sRGB)
 private let imageContextBitsPerComponent = 8
 private let imageContextBytesPerPixel = 4
 
-private func compare(_ old: UIImage, _ new: UIImage, precision: Float, perceptualPrecision: Float) -> Bool {
-  guard let oldCgImage = old.cgImage else { return false }
-  guard let newCgImage = new.cgImage else { return false }
-  guard newCgImage.width != 0 else { return false }
-  guard oldCgImage.width == newCgImage.width else { return false }
-  guard newCgImage.height != 0 else { return false }
-  guard oldCgImage.height == newCgImage.height else { return false }
-
+private func compare(_ old: UIImage, _ new: UIImage, precision: Float, perceptualPrecision: Float) -> String? {
+  guard let oldCgImage = old.cgImage else {
+    return "Reference image could not be loaded."
+  }
+  guard let newCgImage = new.cgImage else {
+    return "Newly-taken snapshot could not be loaded."
+  }
+  guard newCgImage.width != 0, newCgImage.height != 0 else {
+    return "Newly-taken snapshot is empty."
+  }
+  guard oldCgImage.width == newCgImage.width, oldCgImage.height == newCgImage.height else {
+    return "Newly-taken snapshot@\(new.size) does not match reference@\(old.size)."
+  }
   let pixelCount = oldCgImage.width * oldCgImage.height
   let byteCount = imageContextBytesPerPixel * pixelCount
   var oldBytes = [UInt8](repeating: 0, count: byteCount)
-  guard let oldContext = context(for: oldCgImage, data: &oldBytes) else { return false }
-  guard let oldData = oldContext.data else { return false }
-  if let newContext = context(for: newCgImage), let newData = newContext.data {
-    if memcmp(oldData, newData, byteCount) == 0 { return true }
+  guard let oldData = context(for: oldCgImage, data: &oldBytes)?.data else {
+    return "Reference image's data could not be loaded."
   }
-  let newer = UIImage(data: new.pngData()!)!
-  guard let newerCgImage = newer.cgImage else { return false }
+  if let newContext = context(for: newCgImage), let newData = newContext.data {
+    if memcmp(oldData, newData, byteCount) == 0 { return nil }
+  }
   var newerBytes = [UInt8](repeating: 0, count: byteCount)
-  guard let newerContext = context(for: newerCgImage, data: &newerBytes) else { return false }
-  guard let newerData = newerContext.data else { return false }
-  if memcmp(oldData, newerData, byteCount) == 0 { return true }
-  if precision >= 1, perceptualPrecision >= 1 { return false }
+  guard
+    let pngData = new.pngData(),
+    let newerCgImage = UIImage(data: pngData)?.cgImage,
+    let newerContext = context(for: newerCgImage, data: &newerBytes),
+    let newerData = newerContext.data
+  else {
+    return "Newly-taken snapshot's data could not be loaded."
+  }
+  if memcmp(oldData, newerData, byteCount) == 0 { return nil }
+  if precision >= 1, perceptualPrecision >= 1 {
+    return "Newly-taken snapshot does not match reference."
+  }
   if perceptualPrecision < 1, #available(iOS 11.0, tvOS 11.0, *) {
-    let deltaFilter = CIFilter(
-      name: "CILabDeltaE",
-      parameters: [
-        kCIInputImageKey: CIImage(cgImage: newCgImage),
-        "inputImage2": CIImage(cgImage: oldCgImage)
-      ]
+    return perceptuallyCompare(
+      CIImage(cgImage: oldCgImage),
+      CIImage(cgImage: newCgImage),
+      pixelPrecision: precision,
+      perceptualPrecision: perceptualPrecision
     )
-    guard let deltaOutputImage = deltaFilter?.outputImage else { return false }
-    let extent = CGRect(x: 0, y: 0, width: oldCgImage.width, height: oldCgImage.height)
-    guard
-      let thresholdOutputImage = try? ThresholdImageProcessorKernel.apply(
-        withExtent: extent,
-        inputs: [deltaOutputImage],
-        arguments: [ThresholdImageProcessorKernel.inputThresholdKey: (1 - perceptualPrecision) * 100]
-      )
-    else { return false }
-    let averageFilter = CIFilter(
-      name: "CIAreaAverage",
-      parameters: [
-        kCIInputImageKey: thresholdOutputImage,
-        kCIInputExtentKey: extent
-      ]
-    )
-    guard let averageOutputImage = averageFilter?.outputImage else { return false }
-    var averagePixel: Float = 0
-    CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()]).render(
-      averageOutputImage,
-      toBitmap: &averagePixel,
-      rowBytes: MemoryLayout<Float>.size,
-      bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
-      format: .Rf,
-      colorSpace: nil
-    )
-    let pixelCountThreshold = 1 - precision
-    if averagePixel > pixelCountThreshold { return false }
   } else {
     let byteCountThreshold = Int((1 - precision) * Float(byteCount))
     var differentByteCount = 0
     for offset in 0..<byteCount {
       if oldBytes[offset] != newerBytes[offset] {
         differentByteCount += 1
-        if differentByteCount > byteCountThreshold { return false }
       }
     }
+    if differentByteCount > byteCountThreshold {
+      let actualPrecision = 1 - Float(differentByteCount) / Float(byteCount)
+      return "Actual image precision \(actualPrecision) is less than required \(precision)"
+    }
   }
-  return true
+  return nil
 }
 
 private func context(for cgImage: CGImage, data: UnsafeMutableRawPointer? = nil) -> CGContext? {
@@ -188,6 +170,51 @@ private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
 #if os(iOS) || os(tvOS) || os(macOS)
 import CoreImage.CIKernel
 import MetalPerformanceShaders
+
+@available(iOS 10.0, tvOS 10.0, macOS 10.13, *)
+func perceptuallyCompare(_ old: CIImage, _ new: CIImage, pixelPrecision: Float, perceptualPrecision: Float) -> String? {
+  let deltaOutputImage = old.applyingFilter("CILabDeltaE", parameters: ["inputImage2": new])
+  let thresholdOutputImage: CIImage
+  do {
+    thresholdOutputImage = try ThresholdImageProcessorKernel.apply(
+      withExtent: new.extent,
+      inputs: [deltaOutputImage],
+      arguments: [ThresholdImageProcessorKernel.inputThresholdKey: (1 - perceptualPrecision) * 100]
+    )
+  } catch {
+    return "Newly-taken snapshot's data could not be loaded. \(error)"
+  }
+  var averagePixel: Float = 0
+  let context = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
+  context.render(
+    thresholdOutputImage.applyingFilter("CIAreaAverage", parameters: [kCIInputExtentKey: new.extent]),
+    toBitmap: &averagePixel,
+    rowBytes: MemoryLayout<Float>.size,
+    bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+    format: .Rf,
+    colorSpace: nil
+  )
+  let actualPixelPrecision = 1 - averagePixel
+  guard actualPixelPrecision < pixelPrecision else { return nil }
+  var maximumDeltaE: Float = 0
+  context.render(
+    deltaOutputImage.applyingFilter("CIAreaMaximum", parameters: [kCIInputExtentKey: new.extent]),
+    toBitmap: &maximumDeltaE,
+    rowBytes: MemoryLayout<Float>.size,
+    bounds: CGRect(x: 0, y: 0, width: 1, height: 1),
+    format: .Rf,
+    colorSpace: nil
+  )
+  let actualPerceptualPrecision = 1 - maximumDeltaE / 100
+  if pixelPrecision < 1 {
+    return """
+    Actual image precision \(actualPixelPrecision) is less than required \(pixelPrecision)
+    Actual perceptual precision \(actualPerceptualPrecision) is less than required \(perceptualPrecision)
+    """
+  } else {
+    return "Actual perceptual precision \(actualPerceptualPrecision) is less than required \(perceptualPrecision)"
+  }
+}
 
 // Copied from https://developer.apple.com/documentation/coreimage/ciimageprocessorkernel
 @available(iOS 10.0, tvOS 10.0, macOS 10.13, *)


### PR DESCRIPTION
A follow-up to https://github.com/pointfreeco/swift-snapshot-testing/pull/62 specifically this comment https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1250404163

This PR updates the image comparison methods to report a failure message rather than just a boolean of whether the comparison passed or failed. This failure message provides more insight into the reason why a snapshot assertion failed. This is especially helpful when the image differences are subtle - such as the "ghost" differences mentioned in https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1250224235

![Fancy logo](https://user-images.githubusercontent.com/915431/191623637-c07cdbef-73d6-4eaa-825d-81fab6401288.png#gh-light-mode-only)
![Fancy logo](https://user-images.githubusercontent.com/915431/191623683-8d34af0f-a607-4753-ab8f-74d2d307ca6f.png#gh-dark-mode-only)
