### PR TITLE
Image precision default value variable

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -16,6 +16,30 @@ public var record: Bool {
   set { isRecording = newValue }
 }
 
+/// The default precision used in image snapshot comparisons.
+///
+/// Represents a percentage of pixels in the snapshot that must match the reference image.
+///
+/// - Precondition: Value is a percentage that should be within the range `0...1`.
+public var defaultImagePrecision: Float = 1
+
+/// The default perceptual precision used in image snapshot comparisons.
+///
+/// Represents how perceptually similar pixels must be to consider them matching.
+/// The value is the inverse of a [Delta E](http://zschuessler.github.io/DeltaE/learn#toc-defining-delta-e).
+///
+/// | Value | Description                                                       |
+/// | ----: | :---------------------------------------------------------------- |
+/// |  100% | Images must be _exactly_ equal                                    |
+/// | ≥ 99% | Allows differences imperceptible by human eyes                    |
+/// | ≥ 98% | Allows differences possibly perceptible through close observation |
+/// | ≥ 90% | Allows differences perceptible at a glance                        |
+/// | ≥ 50% | Allows differences when more similar than not                     |
+/// |  ≥ 0% | Allows any differences                                            |
+///
+/// - Precondition: Value is a percentage that should be within the range `0...1`.
+public var defaultImagePerceptualPrecision: Float = 1
+
 /// Asserts that a given value matches a reference on disk.
 ///
 /// - Parameters:

--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -4,7 +4,7 @@ import Cocoa
 extension Snapshotting where Value == CALayer, Format == NSImage {
   /// A snapshot strategy for comparing layers based on pixel equality.
   public static var image: Snapshotting {
-    return .image(precision: 1)
+    return .image()
   }
 
   /// A snapshot strategy for comparing layers based on pixel equality.
@@ -12,7 +12,7 @@ extension Snapshotting where Value == CALayer, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { layer in
       let image = NSImage(size: layer.bounds.size)
       image.lockFocus()
@@ -40,7 +40,7 @@ extension Snapshotting where Value == CALayer, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - traits: A trait collection override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, traits: UITraitCollection = .init())
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, traits: UITraitCollection = .init())
     -> Snapshotting {
       return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: traits.displayScale).pullback { layer in
         renderer(bounds: layer.bounds, for: traits).image { ctx in

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == CGPath, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { path in
       let bounds = path.boundingBoxOfPath
       var transform = CGAffineTransform(translationX: -bounds.origin.x, y: -bounds.origin.y)
@@ -43,7 +43,7 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.boundingBoxOfPath
       let format: UIGraphicsImageRendererFormat

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == NSBezierPath, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { path in
       // Move path info frame:
       let bounds = path.bounds

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -12,7 +12,7 @@ extension Diffing where Value == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   /// - Returns: A new diffing strategy.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Diffing {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision) -> Diffing {
     return .init(
       toData: { NSImagePNGRepresentation($0)! },
       fromData: { NSImage(data: $0)! }
@@ -44,7 +44,7 @@ extension Snapshotting where Value == NSImage, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision) -> Snapshotting {
     return .init(
       pathExtension: "png",
       diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision)

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == NSView, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: A view size override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize? = nil) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).asyncPullback { view in
       let initialSize = view.frame.size
       if let size = size { view.frame.size = size }

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == NSViewController, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: A view size override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize? = nil) -> Snapshotting {
     return Snapshotting<NSView, NSImage>.image(precision: precision, perceptualPrecision: perceptualPrecision, size: size).pullback { $0.view }
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -14,7 +14,7 @@ extension Snapshotting where Value == SCNScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize) -> Snapshotting {
     return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }
@@ -26,7 +26,7 @@ extension Snapshotting where Value == SCNScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize) -> Snapshotting {
     return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -14,7 +14,7 @@ extension Snapshotting where Value == SKScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize) -> Snapshotting {
     return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }
@@ -26,7 +26,7 @@ extension Snapshotting where Value == SKScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, size: CGSize) -> Snapshotting {
     return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -33,8 +33,8 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = defaultImagePrecision,
+    perceptualPrecision: Float = defaultImagePerceptualPrecision,
     layout: SwiftUISnapshotLayout = .sizeThatFits,
     traits: UITraitCollection = .init()
     )

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: The scale to use when loading the reference image from disk.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, scale: CGFloat = 1) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.bounds
       let format: UIGraphicsImageRendererFormat

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -13,7 +13,7 @@ extension Diffing where Value == UIImage {
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: Scale to use when loading the reference image from disk. If `nil` or the `UITraitCollection`s default value of `0.0`, the screens scale is used.
   /// - Returns: A new diffing strategy.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil) -> Diffing {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, scale: CGFloat? = nil) -> Diffing {
     let imageScale: CGFloat
     if let scale = scale, scale != 0.0 {
       imageScale = scale
@@ -64,7 +64,7 @@ extension Snapshotting where Value == UIImage, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: The scale of the reference image stored on disk.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil) -> Snapshotting {
+  public static func image(precision: Float = defaultImagePrecision, perceptualPrecision: Float = defaultImagePerceptualPrecision, scale: CGFloat? = nil) -> Snapshotting {
     return .init(
       pathExtension: "png",
       diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale)

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -17,8 +17,8 @@ extension Snapshotting where Value == UIView, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = defaultImagePrecision,
+    perceptualPrecision: Float = defaultImagePerceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -17,8 +17,8 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     on config: ViewImageConfig,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = defaultImagePrecision,
+    perceptualPrecision: Float = defaultImagePerceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )
@@ -45,8 +45,8 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = defaultImagePrecision,
+    perceptualPrecision: Float = defaultImagePerceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )


### PR DESCRIPTION
## Overview
A follow-up on https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1246768428

This PR adds global variables that control the default image `precision` and `perceptualPrecision` parameter values when no value is specified in the `Snapshotting.image()` method.

This makes it simple to configure snapshot tests with precision values that accommodate subtle differences between device rendering. Such as the [imperceptible differences in Intel and Apple Silicon hardware accelerated anti-aliasing, shadow, and blur rendering](https://github.com/pointfreeco/swift-snapshot-testing/issues/424).

### Alternatives considered:
Integrators could add [overloading extensions that override `Snapshotting.image()` parameter defaults](https://github.com/pointfreeco/swift-snapshot-testing/pull/628#issuecomment-1246800844). But, this requires more code to be written by the integrator and is more susceptible to breakage and infinite recursion.