### PR TITLE
Add default configuration options

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -155,6 +155,7 @@ public func assertSnapshots<Value, Format>(
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
 ///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
+///   - snapshotSubdirectory: The default subdirectory for snapshots in the same directory as the test file. Defaults to `__Snapshots__` that sits next to your test file. Only used when `snapshotDirectory` is nil.
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
@@ -165,8 +166,9 @@ public func verifySnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool = false,
-  snapshotDirectory: String? = nil,
-  timeout: TimeInterval = 5,
+  snapshotDirectory: String? = SnapshottingDefaults.snapshotDirectory,
+  snapshotSubdirectory: String = SnapshottingDefaults.snapshotSubdirectory,
+  timeout: TimeInterval = SnapshottingDefaults.timeout,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
@@ -183,7 +185,7 @@ public func verifySnapshot<Value, Format>(
       let snapshotDirectoryUrl = snapshotDirectory.map { URL(fileURLWithPath: $0, isDirectory: true) }
         ?? fileUrl
           .deletingLastPathComponent()
-          .appendingPathComponent("__Snapshots__")
+          .appendingPathComponent(snapshotSubdirectory)
           .appendingPathComponent(fileName)
 
       let identifier: String

--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == CALayer, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { layer in
       let image = NSImage(size: layer.bounds.size)
       image.lockFocus()
@@ -40,7 +40,7 @@ extension Snapshotting where Value == CALayer, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - traits: A trait collection override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, traits: UITraitCollection = .init())
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, traits: UITraitCollection = .init())
     -> Snapshotting {
       return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: traits.displayScale).pullback { layer in
         renderer(bounds: layer.bounds, for: traits).image { ctx in

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == CGPath, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { path in
       let bounds = path.boundingBoxOfPath
       var transform = CGAffineTransform(translationX: -bounds.origin.x, y: -bounds.origin.y)
@@ -43,7 +43,7 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.boundingBoxOfPath
       let format: UIGraphicsImageRendererFormat

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == NSBezierPath, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).pullback { path in
       // Move path info frame:
       let bounds = path.bounds

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -12,7 +12,7 @@ extension Diffing where Value == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   /// - Returns: A new diffing strategy.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Diffing {
+  public static func image(precision: Float = 1, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision) -> Diffing {
     return .init(
       toData: { NSImagePNGRepresentation($0)! },
       fromData: { NSImage(data: $0)! }
@@ -44,7 +44,7 @@ extension Snapshotting where Value == NSImage, Format == NSImage {
   /// - Parameters:
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1) -> Snapshotting {
+  public static func image(precision: Float = 1, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision) -> Snapshotting {
     return .init(
       pathExtension: "png",
       diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision)

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == NSView, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: A view size override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize? = nil) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision).asyncPullback { view in
       let initialSize = view.frame.size
       if let size = size { view.frame.size = size }

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == NSViewController, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: A view size override.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize? = nil) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize? = nil) -> Snapshotting {
     return Snapshotting<NSView, NSImage>.image(precision: precision, perceptualPrecision: perceptualPrecision, size: size).pullback { $0.view }
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -14,7 +14,7 @@ extension Snapshotting where Value == SCNScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize) -> Snapshotting {
     return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }
@@ -26,7 +26,7 @@ extension Snapshotting where Value == SCNScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize) -> Snapshotting {
     return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SnapshottingDefaults.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SnapshottingDefaults.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// The global configuration options
+public enum SnapshottingDefaults {
+    /// The default subdirectory for snapshots in the same directory as the test file. Defaults to `__Snapshots__` that sits next to your test file. Only used when `snapshotDirectory` is nil.
+    public static var snapshotSubdirectory = "__Snapshots__"
+    /// Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
+    public static var snapshotDirectory: String? = nil
+    /// The amount of time a snapshot must be generated in.
+    public static var timeout: TimeInterval = 5
+    /// The percentage of pixels that must match. Value between 0-1
+    public static var precision: Float = 1
+
+    /// The byte-value threshold at which two subpixels are considered different. Value between 0-255
+    public static var perceptualPrecision: Float = 1
+}

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -14,7 +14,7 @@ extension Snapshotting where Value == SKScene, Format == NSImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize) -> Snapshotting {
     return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }
@@ -26,7 +26,7 @@ extension Snapshotting where Value == SKScene, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - size: The size of the scene.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, size: CGSize) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, size: CGSize) -> Snapshotting {
     return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
   }
 }

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -33,8 +33,8 @@ extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = SnapshottingDefaults.precision,
+    perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision,
     layout: SwiftUISnapshotLayout = .sizeThatFits,
     traits: UITraitCollection = .init()
     )

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -13,7 +13,7 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: The scale to use when loading the reference image from disk.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
+  public static func image(precision: Float = SnapshottingDefaults.precision, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, scale: CGFloat = 1) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.bounds
       let format: UIGraphicsImageRendererFormat

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -13,7 +13,7 @@ extension Diffing where Value == UIImage {
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: Scale to use when loading the reference image from disk. If `nil` or the `UITraitCollection`s default value of `0.0`, the screens scale is used.
   /// - Returns: A new diffing strategy.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil) -> Diffing {
+  public static func image(precision: Float = 1, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, scale: CGFloat? = nil) -> Diffing {
     let imageScale: CGFloat
     if let scale = scale, scale != 0.0 {
       imageScale = scale
@@ -65,7 +65,7 @@ extension Snapshotting where Value == UIImage, Format == UIImage {
   ///   - precision: The percentage of pixels that must match.
   ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a match. [98-99% mimics the precision of the human eye.](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e)
   ///   - scale: The scale of the reference image stored on disk.
-  public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat? = nil) -> Snapshotting {
+  public static func image(precision: Float = 1, perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision, scale: CGFloat? = nil) -> Snapshotting {
     return .init(
       pathExtension: "png",
       diffing: .image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale)

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -17,8 +17,8 @@ extension Snapshotting where Value == UIView, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = SnapshottingDefaults.precision,
+    perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -17,8 +17,8 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     on config: ViewImageConfig,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = SnapshottingDefaults.precision,
+    perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )
@@ -45,8 +45,8 @@ extension Snapshotting where Value == UIViewController, Format == UIImage {
   ///   - traits: A trait collection override.
   public static func image(
     drawHierarchyInKeyWindow: Bool = false,
-    precision: Float = 1,
-    perceptualPrecision: Float = 1,
+    precision: Float = SnapshottingDefaults.precision,
+    perceptualPrecision: Float = SnapshottingDefaults.perceptualPrecision,
     size: CGSize? = nil,
     traits: UITraitCollection = .init()
     )


### PR DESCRIPTION
Adding a set of public properties to use as default for all tests. Allows configuration of these properties on a global level

- `precision`
- `perceptualPrecision`
- `timeout`
- `snapshotSubdirectory`
- `snapshotDirectory`

*Motivation*

Providing an easy way to configure things like `perceptualPrecision` introduced in #424 when someone wants to apply it globally without having to write a ton of overrides. All of these options could be made configurable through the use of a plugin by writing a ton of extensions and passed in values. Snapshot location might be the toughest to do because we would need to reimplement the default behavior of a directory name at the same path as the file.

My work is similar to #641 but it allows for more customization