### PR TITLE
Remove obsolete availability checks

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -128,10 +128,8 @@ public struct ViewImageConfig {
     return .init(safeArea: safeArea, size: size, traits: .iPhoneXsMax(orientation))
   }
 
-  @available(iOS 11.0, *)
   public static let iPhoneXr = ViewImageConfig.iPhoneXr(.portrait)
 
-  @available(iOS 11.0, *)
   public static func iPhoneXr(_ orientation: Orientation) -> ViewImageConfig {
     let safeArea: UIEdgeInsets
     let size: CGSize
@@ -830,38 +828,26 @@ extension View {
     if let scnView = self as? SCNView {
       return Async(value: inWindow { scnView.snapshot() })
     } else if let skView = self as? SKView {
-      if #available(macOS 10.11, *) {
-        let cgImage = inWindow { skView.texture(from: skView.scene!)!.cgImage() }
-        #if os(macOS)
-        let image = Image(cgImage: cgImage, size: skView.bounds.size)
-        #elseif os(iOS) || os(tvOS)
-        let image = Image(cgImage: cgImage)
-        #endif
-        return Async(value: image)
-      } else {
-        fatalError("Taking SKView snapshots requires macOS 10.11 or greater")
-      }
+      let cgImage = inWindow { skView.texture(from: skView.scene!)!.cgImage() }
+      #if os(macOS)
+      let image = Image(cgImage: cgImage, size: skView.bounds.size)
+      #elseif os(iOS) || os(tvOS)
+      let image = Image(cgImage: cgImage)
+      #endif
+      return Async(value: image)
     }
     #if os(iOS) || os(macOS)
     if let wkWebView = self as? WKWebView {
       return Async<Image> { callback in
         let work = {
-          if #available(iOS 11.0, macOS 10.13, *) {
-            inWindow {
-              guard wkWebView.frame.width != 0, wkWebView.frame.height != 0 else {
-                callback(Image())
-                return
-              }
-              wkWebView.takeSnapshot(with: nil) { image, _ in
-                callback(image!)
-              }
+          inWindow {
+            guard wkWebView.frame.width != 0, wkWebView.frame.height != 0 else {
+              callback(Image())
+              return
             }
-          } else {
-            #if os(iOS)
-            fatalError("Taking WKWebView snapshots requires iOS 11.0 or greater")
-            #elseif os(macOS)
-            fatalError("Taking WKWebView snapshots requires macOS 10.13 or greater")
-            #endif
+            wkWebView.takeSnapshot(with: nil) { image, _ in
+              callback(image!)
+            }
           }
         }
 
@@ -983,13 +969,7 @@ func snapshotView(
 private let offscreen: CGFloat = 10_000
 
 func renderer(bounds: CGRect, for traits: UITraitCollection) -> UIGraphicsImageRenderer {
-  let renderer: UIGraphicsImageRenderer
-  if #available(iOS 11.0, tvOS 11.0, *) {
-    renderer = UIGraphicsImageRenderer(bounds: bounds, format: .init(for: traits))
-  } else {
-    renderer = UIGraphicsImageRenderer(bounds: bounds)
-  }
-  return renderer
+  return UIGraphicsImageRenderer(bounds: bounds, format: .init(for: traits))
 }
 
 private func add(traits: UITraitCollection, viewController: UIViewController, to window: UIWindow) -> () -> Void {
@@ -1043,13 +1023,7 @@ private func add(traits: UITraitCollection, viewController: UIViewController, to
 }
 
 private func getKeyWindow() -> UIWindow? {
-  var window: UIWindow?
-  if #available(iOS 13.0, *) {
-      window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
-  } else {
-      window = UIApplication.sharedIfAvailable?.keyWindow
-  }
-  return window
+  return UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
 }
 
 private final class Window: UIWindow {
@@ -1080,7 +1054,6 @@ private final class Window: UIWindow {
     fatalError("init(coder:) has not been implemented")
   }
 
-  @available(iOS 11.0, *)
   override var safeAreaInsets: UIEdgeInsets {
     #if os(iOS)
     let removeTopInset = self.config.safeArea == .init(top: 20, left: 0, bottom: 0, right: 0)

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -7,7 +7,6 @@ extension Snapshotting where Format == String {
   }
 }
 
-@available(macOS 10.13, watchOS 4.0, tvOS 11.0, *)
 extension Snapshotting where Format == String {
   /// A snapshot strategy for comparing any structure based on their JSON representation.
   public static var json: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -46,12 +46,7 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
   public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1, drawingMode: CGPathDrawingMode = .eoFill) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.boundingBoxOfPath
-      let format: UIGraphicsImageRendererFormat
-      if #available(iOS 11.0, tvOS 11.0, *) {
-        format = UIGraphicsImageRendererFormat.preferred()
-      } else {
-        format = UIGraphicsImageRendererFormat.default()
-      }
+      let format = UIGraphicsImageRendererFormat.preferred()
       format.scale = scale
       return UIGraphicsImageRenderer(bounds: bounds, format: format).image { ctx in
         let cgContext = ctx.cgContext
@@ -64,7 +59,6 @@ extension Snapshotting where Value == CGPath, Format == UIImage {
 #endif
 
 #if os(macOS) || os(iOS) || os(tvOS)
-@available(iOS 11.0, OSX 10.13, tvOS 11.0, *)
 extension Snapshotting where Value == CGPath, Format == String {
   /// A snapshot strategy for comparing bezier paths based on element descriptions.
   public static var elementsDescription: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/Codable.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Codable.swift
@@ -2,7 +2,6 @@ import Foundation
 
 extension Snapshotting where Value: Encodable, Format == String {
   /// A snapshot strategy for comparing encodable structures based on their JSON representation.
-  @available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)
   public static var json: Snapshotting {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -30,7 +30,6 @@ extension Snapshotting where Value == NSBezierPath, Format == NSImage {
 
 extension Snapshotting where Value == NSBezierPath, Format == String {
   /// A snapshot strategy for comparing bezier paths based on pixel equality.
-  @available(iOS 11.0, *)
   public static var elementsDescription: Snapshotting {
     return .elementsDescription(numberFormatter: defaultNumberFormatter)
   }
@@ -38,7 +37,6 @@ extension Snapshotting where Value == NSBezierPath, Format == String {
   /// A snapshot strategy for comparing bezier paths based on pixel equality.
   ///
   /// - Parameter numberFormatter: The number formatter used for formatting points.
-  @available(iOS 11.0, *)
   public static func elementsDescription(numberFormatter: NumberFormatter) -> Snapshotting {
     let namesByType: [NSBezierPath.ElementType: String] = [
       .moveTo: "MoveTo",

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -92,7 +92,7 @@ private func compare(_ old: NSImage, _ new: NSImage, precision: Float, perceptua
   if precision >= 1, perceptualPrecision >= 1 {
     return "Newly-taken snapshot does not match reference."
   }
-  if perceptualPrecision < 1, #available(macOS 10.13, *) {
+  if perceptualPrecision < 1 {
     return perceptuallyCompare(
       CIImage(cgImage: oldCgImage),
       CIImage(cgImage: newCgImage),

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -15,7 +15,6 @@ public enum SwiftUISnapshotLayout {
 }
 
 #if os(iOS) || os(tvOS)
-@available(iOS 13.0, tvOS 13.0, *)
 extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
 
   /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -16,12 +16,7 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   public static func image(precision: Float = 1, perceptualPrecision: Float = 1, scale: CGFloat = 1) -> Snapshotting {
     return SimplySnapshotting.image(precision: precision, perceptualPrecision: perceptualPrecision, scale: scale).pullback { path in
       let bounds = path.bounds
-      let format: UIGraphicsImageRendererFormat
-      if #available(iOS 11.0, tvOS 11.0, *) {
-        format = UIGraphicsImageRendererFormat.preferred()
-      } else {
-        format = UIGraphicsImageRendererFormat.default()
-      }
+      let format = UIGraphicsImageRendererFormat.preferred()
       format.scale = scale
       return UIGraphicsImageRenderer(bounds: bounds, format: format).image { ctx in
         path.fill()
@@ -30,7 +25,6 @@ extension Snapshotting where Value == UIBezierPath, Format == UIImage {
   }
 }
 
-@available(iOS 11.0, tvOS 11.0, *)
 extension Snapshotting where Value == UIBezierPath, Format == String {
   /// A snapshot strategy for comparing bezier paths based on pixel equality.
   public static var elementsDescription: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -113,7 +113,7 @@ private func compare(_ old: UIImage, _ new: UIImage, precision: Float, perceptua
   if precision >= 1, perceptualPrecision >= 1 {
     return "Newly-taken snapshot does not match reference."
   }
-  if perceptualPrecision < 1, #available(iOS 11.0, tvOS 11.0, *) {
+  if perceptualPrecision < 1 {
     return perceptuallyCompare(
       CIImage(cgImage: oldCgImage),
       CIImage(cgImage: newCgImage),
@@ -172,7 +172,6 @@ private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
 import CoreImage.CIKernel
 import MetalPerformanceShaders
 
-@available(iOS 10.0, tvOS 10.0, macOS 10.13, *)
 func perceptuallyCompare(_ old: CIImage, _ new: CIImage, pixelPrecision: Float, perceptualPrecision: Float) -> String? {
   let deltaOutputImage = old.applyingFilter("CILabDeltaE", parameters: ["inputImage2": new])
   let thresholdOutputImage: CIImage
@@ -218,7 +217,6 @@ func perceptuallyCompare(_ old: CIImage, _ new: CIImage, pixelPrecision: Float, 
 }
 
 // Copied from https://developer.apple.com/documentation/coreimage/ciimageprocessorkernel
-@available(iOS 10.0, tvOS 10.0, macOS 10.13, *)
 final class ThresholdImageProcessorKernel: CIImageProcessorKernel {
   static let inputThresholdKey = "thresholdValue"
   static let device = MTLCreateSystemDefaultDevice()

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -20,7 +20,7 @@ extension Snapshotting where Value == URLRequest, Format == String {
 
       let body: [String]
       do {
-        if pretty, #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+        if pretty {
           body = try request.httpBody
             .map { try JSONSerialization.jsonObject(with: $0, options: []) }
             .map { try JSONSerialization.data(withJSONObject: $0, options: [.prettyPrinted, .sortedKeys]) }

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -43,7 +43,6 @@ final class SnapshotTestingTests: XCTestCase {
     """)
   }
 
-  @available(macOS 10.13, tvOS 11.0, *)
   func testAnyAsJson() throws {
     struct User: Encodable { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
@@ -167,9 +166,7 @@ final class SnapshotTestingTests: XCTestCase {
       assertSnapshot(matching: path, as: .image, named: osName)
     }
 
-    if #available(iOS 11.0, OSX 10.13, tvOS 11.0, *) {
-      assertSnapshot(matching: path, as: .elementsDescription, named: osName)
-    }
+    assertSnapshot(matching: path, as: .elementsDescription, named: osName)
     #endif
   }
 
@@ -183,9 +180,7 @@ final class SnapshotTestingTests: XCTestCase {
     struct User: Encodable { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
 
-    if #available(iOS 11.0, macOS 10.13, tvOS 11.0, *) {
-      assertSnapshot(matching: user, as: .json)
-    }
+    assertSnapshot(matching: user, as: .json)
     assertSnapshot(matching: user, as: .plist)
   }
 
@@ -301,9 +296,7 @@ final class SnapshotTestingTests: XCTestCase {
     #endif
 
     assertSnapshot(matching: image, as: .image(precision: 0.995), named: "exact")
-    if #available(iOS 11.0, tvOS 11.0, macOS 10.13, *) {
-      assertSnapshot(matching: image, as: .image(perceptualPrecision: 0.98), named: "perceptual")
-    }
+    assertSnapshot(matching: image, as: .image(perceptualPrecision: 0.98), named: "perceptual")
     #endif
   }
 
@@ -408,7 +401,6 @@ final class SnapshotTestingTests: XCTestCase {
 
   func testTraits() {
     #if os(iOS) || os(tvOS)
-    if #available(iOS 11.0, tvOS 11.0, *) {
       class MyViewController: UIViewController {
         let topLabel = UILabel()
         let leadingLabel = UILabel()
@@ -579,13 +571,11 @@ final class SnapshotTestingTests: XCTestCase {
       assertSnapshot(
         matching: viewController, as: .image(on: .tv4K), named: "tv4k")
       #endif
-    }
     #endif
   }
 
   func testTraitsEmbeddedInTabNavigation() {
     #if os(iOS)
-    if #available(iOS 11.0, *) {
       class MyViewController: UIViewController {
         let topLabel = UILabel()
         let leadingLabel = UILabel()
@@ -695,7 +685,6 @@ final class SnapshotTestingTests: XCTestCase {
         matching: viewController, as: .image(on: .iPadPro11(.portrait)), named: "ipad-pro-11-alternative")
       assertSnapshot(
         matching: viewController, as: .image(on: .iPadPro12_9(.portrait)), named: "ipad-pro-12-9-alternative")
-    }
     #endif
   }
 
@@ -781,19 +770,17 @@ final class SnapshotTestingTests: XCTestCase {
 
   func testTraitsWithView() {
     #if os(iOS)
-    if #available(iOS 11.0, *) {
-      let label = UILabel()
-      label.font = .preferredFont(forTextStyle: .title1)
-      label.adjustsFontForContentSizeCategory = true
-      label.text = "What's the point?"
+    let label = UILabel()
+    label.font = .preferredFont(forTextStyle: .title1)
+    label.adjustsFontForContentSizeCategory = true
+    label.text = "What's the point?"
 
-      allContentSizes.forEach { name, contentSize in
-        assertSnapshot(
-          matching: label,
-          as: .image(traits: .init(preferredContentSizeCategory: contentSize)),
-          named: "label-\(name)"
-        )
-      }
+    allContentSizes.forEach { name, contentSize in
+      assertSnapshot(
+        matching: label,
+        as: .image(traits: .init(preferredContentSizeCategory: contentSize)),
+        named: "label-\(name)"
+      )
     }
     #endif
   }
@@ -840,9 +827,7 @@ final class SnapshotTestingTests: XCTestCase {
       assertSnapshot(matching: path, as: .image, named: osName)
     }
 
-    if #available(iOS 11.0, tvOS 11.0, *) {
-      assertSnapshot(matching: path, as: .elementsDescription, named: osName)
-    }
+    assertSnapshot(matching: path, as: .elementsDescription, named: osName)
     #endif
   }
 
@@ -1176,7 +1161,6 @@ final class SnapshotTestingTests: XCTestCase {
   #endif
 
   #if os(iOS)
-  @available(iOS 13.0, *)
   func testSwiftUIView_iOS() {
     struct MyView: SwiftUI.View {
       var body: some SwiftUI.View {
@@ -1200,7 +1184,6 @@ final class SnapshotTestingTests: XCTestCase {
   #endif
 
   #if os(tvOS)
-  @available(tvOS 13.0, *)
   func testSwiftUIView_tvOS() {
     struct MyView: SwiftUI.View {
       var body: some SwiftUI.View {


### PR DESCRIPTION
PR https://github.com/pointfreeco/swift-snapshot-testing/pull/640 bumped the minimum deployment targets making these availability checks obsolete.