### PR TITLE
Improve byte buffer iteration speed by 90%

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -104,7 +104,7 @@ private func compare(_ old: NSImage, _ new: NSImage, precision: Float, perceptua
     let newRep = NSBitmapImageRep(cgImage: newerCgImage).bitmapData!
     let byteCountThreshold = Int((1 - precision) * Float(byteCount))
     var differentByteCount = 0
-    for offset in 0..<byteCount {
+    fastForEach(in: 0..<byteCount) { offset in
       if oldRep[offset] != newRep[offset] {
         differentByteCount += 1
       }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -123,7 +123,7 @@ private func compare(_ old: UIImage, _ new: UIImage, precision: Float, perceptua
   } else {
     let byteCountThreshold = Int((1 - precision) * Float(byteCount))
     var differentByteCount = 0
-    for offset in 0..<byteCount {
+    fastForEach(in: 0..<byteCount) { offset in
       if oldBytes[offset] != newerBytes[offset] {
         differentByteCount += 1
       }
@@ -249,3 +249,13 @@ final class ThresholdImageProcessorKernel: CIImageProcessorKernel {
   }
 }
 #endif
+
+/// When the compiler doesn't have optimizations enabled, like in test targets, a `while` loop is significantly faster than a `for` loop
+/// for iterating through the elements of a memory buffer. Details can be found in [SR-6983](https://github.com/apple/swift/issues/49531)
+func fastForEach(in range: Range<Int>, _ body: (Int) -> Void) {
+  var index = range.lowerBound
+  while index < range.upperBound {
+    body(index)
+    index += 1
+  }
+}


### PR DESCRIPTION
## Overview
Improves the speed of comparing memory buffers by using an alternative to `for in` which is significantly slower when compiler optimizations are disabled - such as most unit test scenarios. [SR-6983](https://github.com/apple/swift/issues/49531)

<img width="250" alt="Benchmark" src="https://user-images.githubusercontent.com/915431/197308903-a1b712b0-8101-41a2-886e-d4d54b0fbf73.png">

### Related Issues:
* This PR adds a similar speedup as https://github.com/pointfreeco/swift-snapshot-testing/pull/628 but for the non-perceptual image comparison case
* Closes https://github.com/pointfreeco/swift-snapshot-testing/issues/573 for the non-perceptual image comparison case