### PR TITLE
Make the image paths in Xcode XCTest output clickable

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -249,7 +249,7 @@ public func verifySnapshot<Value, Format>(
           ? """
             Record mode is on. Turn record mode off and re-run "\(testName)" to test against the newly-recorded snapshot.
 
-            open "\(snapshotFileUrl.path)"
+            open "\(snapshotFileUrl.absoluteString)"
 
             Recorded snapshot: …
             """
@@ -302,9 +302,9 @@ public func verifySnapshot<Value, Format>(
         .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
         ?? """
         @\(minus)
-        "\(snapshotFileUrl.path)"
+        "\(snapshotFileUrl.absoluteString)"
         @\(plus)
-        "\(failedSnapshotFileUrl.path)"
+        "\(failedSnapshotFileUrl.absoluteString)"
 
         To configure output for a custom diff tool, like Kaleidoscope:
 


### PR DESCRIPTION
Simple change to print absolute paths if you are not using a diffing tool. This preserves the scheme of the URL , making the experience a bit nicer as you can click on the blue text to navigate to the file in finder. Or you can right click the link and open in a tool of your choice


What I tested:
I don't have KSDIFF installed, so I just eyeballed to double check the output matches. I tested with Xcode on macOS. I don't have access to be able to test other platforms :(.

Output before - when not using a diffTool:
<img width="840" alt="before_notool" src="https://user-images.githubusercontent.com/2643977/201451871-72ba0c84-4dcb-44fa-ae03-6567293dfd7d.png">
Output after - when not using a diffTool (notice you can click on the links to navigate to the files in finder):
<img width="871" alt="after_notool" src="https://user-images.githubusercontent.com/2643977/201451903-ed9be251-004f-4259-98b7-8aea887e6433.png">

Output before - when using KSDiff:
<img width="883" alt="before_ksdiff" src="https://user-images.githubusercontent.com/2643977/201451918-6a708e02-7a2b-4e29-a359-12a6e9181bc7.png">
Output after - when using KSDiff (expected to match the above)
<img width="883" alt="after_ksdiff" src="https://user-images.githubusercontent.com/2643977/201451935-be2cd1e8-afe3-4d82-ad2e-d168565a30f3.png">
