### PR TITLE
Exclude snapshots and fixtures in manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,11 @@ let package = Package(
     .target(name: "SnapshotTesting"),
     .testTarget(
       name: "SnapshotTestingTests",
-      dependencies: ["SnapshotTesting"]
+      dependencies: ["SnapshotTesting"],
+      exclude: [
+        "__Snapshots__",
+        "__Fixtures__"
+      ]
     )
   ]
 )


### PR DESCRIPTION
Solves warning #683 about not handled files.

Not sure if excluding is correct way of handling. 
May be these files should be copied as resources:
```
resources: [
  .copy("__Snapshots__"),
  .copy("__Fixtures__")
]
```