### PR TITLE
Lock Ubuntu CI version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - "5.7"
 
     name: Ubuntu (Swift ${{ matrix.swift }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: swift-actions/setup-swift@v1
         with:


### PR DESCRIPTION
GitHub recently updated their latest version, which doesn't have a Swift package available.