### PR TITLE
Add dumpWith to enable further transformations of the generated string with dump

### DIFF
--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -42,6 +42,18 @@ final class SnapshotTestingTests: XCTestCase {
       - name: "Blobby"
     """)
   }
+	
+  func testAnyTransform() {
+    struct User { let id: Int, name: String, bio: String }
+    let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
+    assertSnapshot(matching: user, as: .dumpWith { $0.replacingOccurrences(of: "Blobby", with: "****") })
+    _assertInlineSnapshot(matching: user, as: .dump, with: """
+     ▿ User
+       - bio: "Blobbed around the world."
+       - id: 1
+       - name: "****"
+     """)
+	}
 
   @available(macOS 10.13, tvOS 11.0, *)
   func testAnyAsJson() throws {


### PR DESCRIPTION
I've had some issues with some objects, where a memory address would not be correctly erased. I think it would be better if this was customizable from the outside, because right now there doesn't seem to be any way to customize the output of the snap function. What do you think?