### PR TITLE
Improve diffs for landscape orientation

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -25,7 +25,7 @@ extension Diffing where Value == UIImage {
       toData: { $0.pngData() ?? emptyImage().pngData()! },
       fromData: { UIImage(data: $0, scale: imageScale)! }
     ) { old, new in
-      let old = UIImage(cgImage: old.cgImage, scale: old.imageScale, orientation: new.imageOrientation)
+      let old = UIImage(cgImage: old.cgImage!, scale: old.scale, orientation: new.imageOrientation)
       guard let message = compare(old, new, precision: precision, perceptualPrecision: perceptualPrecision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
       let oldAttachment = XCTAttachment(image: old)

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -25,6 +25,7 @@ extension Diffing where Value == UIImage {
       toData: { $0.pngData() ?? emptyImage().pngData()! },
       fromData: { UIImage(data: $0, scale: imageScale)! }
     ) { old, new in
+      let old = UIImage(cgImage: old.cgImage, scale: old.imageScale, orientation: new.imageOrientation)
       guard let message = compare(old, new, precision: precision, perceptualPrecision: perceptualPrecision) else { return nil }
       let difference = SnapshotTesting.diff(old, new)
       let oldAttachment = XCTAttachment(image: old)


### PR DESCRIPTION
When snapshot testing screenshots in landscape orientation, the diffs are very noisy as the original orientation of the reference image is ignored and it is treated, for the purpose of the visual diff, as a portrait orientation image.  (The actual comparison seems to work correctly in a pass/fail sense, however.)

Unfortunately, this makes it very hard to see what actually changed.  For example when removing a button in a drawing app I am currently working on, this is the diff I receive in the current version of the repository:
![awful_diff](https://user-images.githubusercontent.com/18686926/208454240-9e7c8406-f5d5-4ed3-a190-f37bf8cbe4b2.jpg)

I believe this issue can be resolved by using the orientation from the new image for the visual diff which results in the following much more readable output:
![sane_diff](https://user-images.githubusercontent.com/18686926/208454416-e185a401-fe05-40b6-a3e2-5f5755bc155e.jpg)

I don't have enough context to know if my solution has drawbacks for the library/community as a whole so I would certainly appreciate review/discussion to see if there is a better solution.