### PR TITLE
Improve wkWebView.takeSnapshot with Xcode 14 and Xcode 15

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -868,7 +868,11 @@
                     callback(Image())
                     return
                   }
-                  wkWebView.takeSnapshot(with: nil) { image, _ in
+                  let configuration = WKSnapshotConfiguration()
+                  if #available(iOS 13, macOS 10.15, *) {
+                    configuration.afterScreenUpdates = false
+                  }
+                  wkWebView.takeSnapshot(with: configuration) { image, _ in
                     callback(image!)
                   }
                 }


### PR DESCRIPTION
This will improve https://github.com/pointfreeco/swift-snapshot-testing/issues/625 a bit. 

Without this patch snapshots crash, with this patch, only the background color of the webview is snapped. 