### PR TITLE
Revert stricter platform requirements

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,9 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13)
+    .iOS(.v11),
+    .macOS(.v10_10),
+    .tvOS(.v10),
   ],
   products: [
     .library(


### PR DESCRIPTION
Fixes #697.

With 1.10.0, a change bumped the platform requirements, but this is hopefully not necessary.