### PR TITLE
Make sure that `perceptuallyCompare` fails if Metal is not available

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -174,6 +174,10 @@ import MetalPerformanceShaders
 
 @available(iOS 10.0, tvOS 10.0, macOS 10.13, *)
 func perceptuallyCompare(_ old: CIImage, _ new: CIImage, pixelPrecision: Float, perceptualPrecision: Float) -> String? {
+  guard nil != MTLCreateSystemDefaultDevice() else {
+    return "Failed to compare snapshots. Metal is required for perceptuallyCompare, but not available on this machine."
+  } 
+
   let deltaOutputImage = old.applyingFilter("CILabDeltaE", parameters: ["inputImage2": new])
   let thresholdOutputImage: CIImage
   do {


### PR DESCRIPTION
## What
Metal is currently unavailable on Github Actions. The `perceptuallyCompare` diffing algorithm relies on Metal render to obtain the level of correspondence to compare it with the given threshold. Snapshot assertions will falsely succeed, even if a given image does not match the stored reference image. 

## Why
The snapshot assertion should fail if it hasn't got the requirements to execute the tests. Currently, the only indication that something's wrong is hidden inside the logs, stating 

I'm aware that there are other initiatives, such as https://github.com/pointfreeco/swift-snapshot-testing/pull/666, which would be perfect, but until this is solved I think it's important to make people aware that the assertions might be wrong when relying on virtual machines without Metal support.

```
[api] No Metal renderer available.
[api] -[CIContext render:toBitmap:rowBytes:bounds:format:colorSpace:] format Rf on GLES.
```

any real issue, any real inconsistency will be undetected when using `perceptuallyCompare` and running on a virtual machine without Metal support.

## How
Added a pre-condition check to `perceptuallyCompare` which will fail when Metal is unavailable.

## Testing 
Any image assertion using `perceptuallyCompare` running on an environment without Metal support. See also https://github.com/mschuetz-viz/DemoSnapshotTest
