### PR TITLE
Configurable SnapshotDirectory to support Xcode cloud workflow

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -133,7 +133,7 @@ public enum SnapshotDirectory {
   /// This style may be configured via an ENV variable, for example to find snapshots
   /// in an available directory for Xcode Cloud.
   ///
-  ///   SNAPSHOTTESTING_PACKAGES_PATH=/Volumes/workspace/respository/ci_scripts/snapshots
+  ///   SNAPSHOTTESTING_PACKAGE_PATH=/Volumes/workspace/respository/ci_scripts/snapshots
   ///
   /// For example:
   ///
@@ -150,11 +150,11 @@ public enum SnapshotDirectory {
   /// This style may be configured via an ENV variable, for example to find snapshots
   /// in an available directory for Xcode Cloud.
   ///
-  ///   SNAPSHOTTESTING_PACKAGES_PATH=/Volumes/workspace/respository/ci_scripts/snapshots
+  ///   SNAPSHOTTESTING_PATH=/Volumes/workspace/respository/ci_scripts/snapshots
   ///
   /// For example:
   ///
-  ///   /Volumes/workspace/respository/ci_scripts/snapshots/MyTests/snapshot1.json
+  ///   /Volumes/workspace/respository/ci_scripts/snapshots/snapshot1.json
   case path(String)
 
   /// Standard directory to save snapshots.
@@ -163,8 +163,8 @@ public enum SnapshotDirectory {
   ///
   ///  `.snapshotsForFile`
   ///
-  ///   /MyProject/MyTests.swift
-  ///   /MyProject/__Snapshots__/MyTests/snapshot.1.json
+  ///   /MyPackage/Tests/MyTests.swift
+  ///   /MyPackage/Tests/__Snapshots__/MyTests/snapshot.1.json
   case snapshotsForFile
 }
 

--- a/Tests/SnapshotTestingTests/SnapshotDirectoryTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotDirectoryTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import SnapshotTesting
+
+final class SnapshotDirectoryTests: XCTestCase {
+
+  func test_packageSnapshotsAtPath() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/SnapshotTests.swift")!
+    let fileName = "SnapshotTests"
+    let path = "/Code/pointfree/snapshots"
+    XCTAssertEqual(
+      SnapshotDirectory.packageSnapshotsAtPath(path).makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/snapshots/SnapshotTestingTests/SnapshotTests"
+    )
+  }
+  func test_packageSnapshotsAtPath_nested() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/Internal/InternalTests.swift")!
+    let fileName = "InternalTests"
+    let path = "/Code/pointfree/snapshots"
+    XCTAssertEqual(
+      SnapshotDirectory.packageSnapshotsAtPath(path).makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/snapshots/SnapshotTestingTests/Internal/InternalTests"
+    )
+  }
+  func test_packageSnapshotsAtPath_not_swift_package() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/NotTests/SnapshotTestingTests/SnapshotTests.swift")!
+    let fileName = "InternalTests"
+    let path = "/Code/pointfree/snapshots"
+    XCTAssertNil(SnapshotDirectory.packageSnapshotsAtPath(path).makeURL(fileUrl: fileUrl, fileName: fileName))
+  }
+
+  func test_path() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/SnapshotTests.swift")!
+    let fileName = "SnapshotTests"
+    let path = "/Code/pointfree/snapshots"
+    XCTAssertEqual(
+      SnapshotDirectory.path(path).makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/snapshots"
+    )
+  }
+  func test_path_nested() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/Internal/InternalTests.swift")!
+    let fileName = "InternalTests"
+    let path = "/Code/pointfree/snapshots"
+    XCTAssertEqual(
+      SnapshotDirectory.path(path).makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/snapshots"
+    )
+  }
+
+  func test_snapshotsForFile() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/SnapshotTests.swift")!
+    let fileName = "SnapshotTests"
+    XCTAssertEqual(
+      SnapshotDirectory.snapshotsForFile.makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTests"
+    )
+  }
+  func test_snapshotsForFile_nested() async throws {
+    let fileUrl = URL(string: "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/Internal/InternalTests.swift")!
+    let fileName = "InternalTests"
+    XCTAssertEqual(
+      SnapshotDirectory.snapshotsForFile.makeURL(fileUrl: fileUrl, fileName: fileName)?.path,
+      "/Code/pointfree/swift-snapshot-testing/Tests/SnapshotTestingTests/Internal/__Snapshots__/InternalTests"
+    )
+  }
+}


### PR DESCRIPTION
Following the thread in #553 it seems there are two steps to using snapshots on Xcode cloud:

1. Snapshot files must be found in the `ci_scripts` directory, which is the only set of files available during a test run. This can be done via symlink.
2. `assertSnapshot` must be called with a `snapshotDirectory` argument pointing to the location of the file's snapshots within the `ci_scripts`  directory.

The project I'm working with has many swift packages, many of which use snapshots. I wanted a way to run the snapshot tests on Xcode cloud without changing the local workflow. 

This change allows configuration of the snapshot directory via ENV var, with an option specifically for this workflow.

---

## 1. Symlink snapshots

This script finds all `__Snapshot__` directories and symlinks them into `ci_scripts/snapshots`. Run it from your project root.

```bash
#!/bin/sh
set -e
snapshots=ci_scripts/snapshots
search_path_from_snapshots=../..
rm -rf $snapshots
mkdir $snapshots
cd $snapshots
find $search_path_from_snapshots -type d -name "__Snapshots__" | grep -v .build | while read dir; do
    parent=$(dirname "$dir")
    parent_name=${parent##*/}
    echo $parent_name $dir
    ln -s "$dir" "$parent_name"
done
```

## 2. Configure the snapshots location for CI

Set an ENV var to change where the library finds snapshots:

```
SNAPSHOTTESTING_PACKAGE_PATH=/Volumes/workspace/respository/ci_scripts/snapshots
```

> Note - I'm currently setting this in a Test Plan, but I think it can be set in a Scheme. Ideally in the Xcode cloud Workflow setup but those vars don't seem to be available to the test run?

The result is that snapshots from all packages are flattened and symlinked into the `ci_scripts` dir, then `SnapshotTesting` constructs a matching path for assertion when run via CI.

