### PR TITLE
Add public access control to snapshotView

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -944,7 +944,7 @@ func prepareView(
   return dispose
 }
 
-func snapshotView(
+public func snapshotView(
   config: ViewImageConfig,
   drawHierarchyInKeyWindow: Bool,
   traits: UITraitCollection,


### PR DESCRIPTION
We have our own asynchronous diffing capabilities that we use for snapshot testing, so we don't really use the diff comparison feature. Our diffing tool allows us to better control the approval workflow. We'd like to use this library for the snapshotting piece of it, though. Currently, we can use the `snapshotView` function directly by importing SnapshotTesting as `@testable`. We're hoping that `snapshotView` can be included the public API to help avoid anything breaking for us in the future.