### PR TITLE
Updated interface

### DIFF
--- a/Documentation/Available-Snapshot-Strategies.md
+++ b/Documentation/Available-Snapshot-Strategies.md
@@ -66,7 +66,7 @@ A snapshot strategy that captures a value's textual description from `String`'s 
 #### Example:
 
 ``` swift
-assertSnapshot(matching: user, as: .description)
+assertSnapshot(of: user, as: .description)
 ```
 
 Records:
@@ -90,7 +90,7 @@ You can hook into how an instance of a type is rendered in this strategy by conf
 #### Example:
 
 ``` swift
-assertSnapshot(matching: user, as: .dump)
+assertSnapshot(of: user, as: .dump)
 ```
 
 Records:
@@ -124,10 +124,10 @@ A snapshot strategy for comparing layers based on pixel equality.
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: layer, as: .image)
+assertSnapshot(of: layer, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: layer, as: .image(precision: 0.99))
+assertSnapshot(of: layer, as: .image(precision: 0.99))
 ```
 
 ## CaseIterable
@@ -160,7 +160,7 @@ enum Direction: String, CaseIterable {
 }
 
 assertSnapshot(
-  matching: { $0.rotatedLeft },
+  of: { $0.rotatedLeft },
   as: Snapshotting<Direction, String>.func(into: .description)
 )
 ```
@@ -194,10 +194,10 @@ A snapshot strategy for comparing paths based on pixel equality.
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .image)
+assertSnapshot(of: path, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: path, as: .image(precision: 0.99))
+assertSnapshot(of: path, as: .image(precision: 0.99))
 ```
 
 ### `.elementsDescription`
@@ -216,10 +216,10 @@ A snapshot strategy for comparing paths based on a description of their elements
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .elementsDescription)
+assertSnapshot(of: path, as: .elementsDescription)
 
 // Match reference as formatted by formatter.
-assertSnapshot(matching: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
+assertSnapshot(of: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
 ```
 
 ## Data
@@ -233,7 +233,7 @@ A snapshot strategy for comparing bare binary data.
 #### Example:
 
 ``` swift
-assertSnapshot(matching: data, as: .data)
+assertSnapshot(of: data, as: .data)
 ```
 
 ## Encodable
@@ -253,7 +253,7 @@ A snapshot strategy for comparing encodable structures based on their JSON repre
 #### Example:
 
 ``` swift
-assertSnapshot(matching: user, as: .json)
+assertSnapshot(of: user, as: .json)
 ```
 
 Records:
@@ -279,7 +279,7 @@ A snapshot strategy for comparing encodable structures based on their property l
 #### Example:
 
 ``` swift
-assertSnapshot(matching: user, as: .plist)
+assertSnapshot(of: user, as: .plist)
 ```
 
 Records:
@@ -319,10 +319,10 @@ A snapshot strategy for comparing paths based on pixel equality.
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .image)
+assertSnapshot(of: path, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: path, as: .image(precision: 0.99))
+assertSnapshot(of: path, as: .image(precision: 0.99))
 ```
 
 ### `.elementsDescription`
@@ -341,10 +341,10 @@ A snapshot strategy for comparing paths based on a description of their elements
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .elementsDescription)
+assertSnapshot(of: path, as: .elementsDescription)
 
 // Match reference as formatted by formatter.
-assertSnapshot(matching: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
+assertSnapshot(of: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
 ```
 
 ## NSImage
@@ -367,10 +367,10 @@ A snapshot strategy for comparing images based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: image, as: .image)
+assertSnapshot(of: image, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: image, as: .image(precision: 0.99))
+assertSnapshot(of: image, as: .image(precision: 0.99))
 ```
 
 ## NSView
@@ -401,14 +401,14 @@ A snapshot strategy for comparing layers based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: view, as: .image)
+assertSnapshot(of: view, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: view, as: .image(precision: 0.99))
+assertSnapshot(of: view, as: .image(precision: 0.99))
 
 // Render at a certain size.
 assertSnapshot(
-  matching: view,
+  of: view,
   as: .image(size: .init(width: 44, height: 44))
 )
 ```
@@ -422,7 +422,7 @@ A snapshot strategy for comparing views based on a recursive description of thei
 #### Example
 
 ``` swift
-assertSnapshot(matching: view, as: .recursiveDescription)
+assertSnapshot(of: view, as: .recursiveDescription)
 ```
 
 Records:
@@ -458,14 +458,14 @@ A snapshot strategy for comparing layers based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: vc, as: .image)
+assertSnapshot(of: vc, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: vc, as: .image(precision: 0.99))
+assertSnapshot(of: vc, as: .image(precision: 0.99))
 
 // Render at a certain size.
 assertSnapshot(
-  matching: vc,
+  of: vc,
   as: .image(size: .init(width: 640, height: 480))
 )
 ```
@@ -481,7 +481,7 @@ A snapshot strategy for comparing view controller views based on a recursive des
 #### Example
 
 ``` swift
-assertSnapshot(matching: vc, as: .recursiveDescription)
+assertSnapshot(of: vc, as: .recursiveDescription)
 ```
 
 Records:
@@ -515,7 +515,7 @@ A snapshot strategy for comparing SceneKit scenes based on pixel equality.
 
 ``` swift
 assertSnapshot(
-  matching: scene,
+  of: scene,
   as: .image(size: .init(width: 640, height: 480))
 )
 ```
@@ -544,7 +544,7 @@ A snapshot strategy for comparing SpriteKit scenes based on pixel equality.
 
 ``` swift
 assertSnapshot(
-  matching: scene,
+  of: scene,
   as: .image(size: .init(width: 640, height: 480))
 )
 ```
@@ -564,7 +564,7 @@ A snapshot strategy for comparing strings based on equality.
 #### Example:
 
 ``` swift
-assertSnapshot(matching: htmlString, as: .lines)
+assertSnapshot(of: htmlString, as: .lines)
 ```
 
 ## UIBezierPath
@@ -587,10 +587,10 @@ A snapshot strategy for comparing paths based on pixel equality.
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .image)
+assertSnapshot(of: path, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: path, as: .image(precision: 0.99))
+assertSnapshot(of: path, as: .image(precision: 0.99))
 ```
 
 ### `.elementsDescription`
@@ -609,10 +609,10 @@ A snapshot strategy for comparing paths based on a description of their elements
 
 ``` swift
 // Match reference perfectly.
-assertSnapshot(matching: path, as: .elementsDescription)
+assertSnapshot(of: path, as: .elementsDescription)
 
 // Match reference as formatted by formatter.
-assertSnapshot(matching: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
+assertSnapshot(of: path, as: .elementsDescription(numberFormatter: NumberFormatter()))
 ```
 
 ## UIImage
@@ -635,10 +635,10 @@ A snapshot strategy for comparing images based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: image, as: .image)
+assertSnapshot(of: image, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: image, as: .image(precision: 0.99))
+assertSnapshot(of: image, as: .image(precision: 0.99))
 ```
 
 ## UIView
@@ -677,20 +677,20 @@ A snapshot strategy for comparing layers based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: view, as: .image)
+assertSnapshot(of: view, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: view, as: .image(precision: 0.99))
+assertSnapshot(of: view, as: .image(precision: 0.99))
 
 // Render at a certain size.
 assertSnapshot(
-  matching: view,
+  of: view,
   as: .image(size: .init(width: 44, height: 44))
 )
 
 // Render with a horizontally-compact size class.
 assertSnapshot(
-  matching: view,
+  of: view,
   as: .image(traits: .init(horizontalSizeClass: .regular))
 )
 ```
@@ -715,13 +715,13 @@ A snapshot strategy for comparing views based on a recursive description of thei
 
 ``` swift
 // Layout on the current device.
-assertSnapshot(matching: view, as: .recursiveDescription)
+assertSnapshot(of: view, as: .recursiveDescription)
 
 // Layout with a certain size.
-assertSnapshot(matching: view, as: .recursiveDescription(size: .init(width: 22, height: 22)))
+assertSnapshot(of: view, as: .recursiveDescription(size: .init(width: 22, height: 22)))
 
 // Layout with a certain trait collection.
-assertSnapshot(matching: view, as: .recursiveDescription(traits: .init(horizontalSizeClass: .regular)))
+assertSnapshot(of: view, as: .recursiveDescription(traits: .init(horizontalSizeClass: .regular)))
 ```
 
 Records:
@@ -744,7 +744,7 @@ A snapshot strategy for comparing view controllers based on their embedded contr
 #### Example
 
 ``` swift
-assertSnapshot(matching: vc, as: .hierarchy)
+assertSnapshot(of: vc, as: .hierarchy)
 ```
 
 Records:
@@ -802,28 +802,28 @@ A snapshot strategy for comparing layers based on pixel equality.
 
 ``` swift
 // Match reference as-is.
-assertSnapshot(matching: vc, as: .image)
+assertSnapshot(of: vc, as: .image)
 
 // Allow for a 1% pixel difference.
-assertSnapshot(matching: vc, as: .image(precision: 0.99))
+assertSnapshot(of: vc, as: .image(precision: 0.99))
 
 // Render as if on a certain device.
-assertSnapshot(matching: vc, as: .image(on: .iPhoneX(.portrait)))
+assertSnapshot(of: vc, as: .image(on: .iPhoneX(.portrait)))
 
 // Render at a certain size.
 assertSnapshot(
-  matching: vc,
+  of: vc,
   as: .image(size: .init(width: 375, height: 667))
 )
 
 // Render with a horizontally-compact size class.
 assertSnapshot(
-  matching: vc,
+  of: vc,
   as: .image(traits: .init(horizontalSizeClass: .compact))
 )
 
 // Match reference as-is.
-assertSnapshot(matching: vc, as: .image)
+assertSnapshot(of: vc, as: .image)
 ```
 
 **See also**: [`UIView`](#uiview).
@@ -852,10 +852,10 @@ A snapshot strategy for comparing view controller views based on a recursive des
 
 ``` swift
 // Layout on the current device.
-assertSnapshot(matching: vc, as: .recursiveDescription)
+assertSnapshot(of: vc, as: .recursiveDescription)
 
 // Layout as if on a certain device.
-assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPhoneSe(.portrait)))
+assertSnapshot(of: vc, as: .recursiveDescription(on: .iPhoneSe(.portrait)))
 ```
 
 Records:
@@ -878,7 +878,7 @@ A snapshot strategy for comparing requests based on a cURL representation.
 #### Example:
 
 ``` swift
-assertSnapshot(matching: request, as: .curl)
+assertSnapshot(of: request, as: .curl)
 ```
 
 Records:
@@ -900,7 +900,7 @@ A snapshot strategy for comparing requests based on raw equality.
 #### Example:
 
 ``` swift
-assertSnapshot(matching: request, as: .raw)
+assertSnapshot(of: request, as: .raw)
 ```
 
 Records:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ class MyViewControllerTests: XCTestCase {
   func testMyViewController() {
     let vc = MyViewController()
 
-    assertSnapshot(matching: vc, as: .image)
+    assertSnapshot(of: vc, as: .image)
   }
 }
 ```
@@ -41,12 +41,12 @@ Repeat test runs will load this reference and compare it with the runtime value.
 You can record a new reference by setting the `record` parameter to `true` on the assertion or setting `isRecording` globally.
 
 ``` swift
-assertSnapshot(matching: vc, as: .image, record: true)
+assertSnapshot(of: vc, as: .image, record: true)
 
 // or globally
 
 isRecording = true
-assertSnapshot(matching: vc, as: .image)
+assertSnapshot(of: vc, as: .image)
 ```
 
 ## Snapshot Anything
@@ -56,24 +56,24 @@ While most snapshot testing libraries in the Swift community are limited to `UII
 The `assertSnapshot` function accepts a value and any snapshot strategy that value supports. This means that a [view](Documentation/Available-Snapshot-Strategies.md#uiview) or [view controller](Documentation/Available-Snapshot-Strategies.md#uiviewcontroller) can be tested against an image representation _and_ against a textual representation of its properties and subview hierarchy.
 
 ``` swift
-assertSnapshot(matching: vc, as: .image)
-assertSnapshot(matching: vc, as: .recursiveDescription)
+assertSnapshot(of: vc, as: .image)
+assertSnapshot(of: vc, as: .recursiveDescription)
 ```
 
 View testing is [highly configurable](Documentation/Available-Snapshot-Strategies.md#uiviewcontroller). You can override trait collections (for specific size classes and content size categories) and generate device-agnostic snapshots, all from a single simulator.
 
 ``` swift
-assertSnapshot(matching: vc, as: .image(on: .iPhoneSe))
-assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPhoneSe))
+assertSnapshot(of: vc, as: .image(on: .iPhoneSe))
+assertSnapshot(of: vc, as: .recursiveDescription(on: .iPhoneSe))
 
-assertSnapshot(matching: vc, as: .image(on: .iPhoneSe(.landscape)))
-assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPhoneSe(.landscape)))
+assertSnapshot(of: vc, as: .image(on: .iPhoneSe(.landscape)))
+assertSnapshot(of: vc, as: .recursiveDescription(on: .iPhoneSe(.landscape)))
 
-assertSnapshot(matching: vc, as: .image(on: .iPhoneX))
-assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPhoneX))
+assertSnapshot(of: vc, as: .image(on: .iPhoneX))
+assertSnapshot(of: vc, as: .recursiveDescription(on: .iPhoneX))
 
-assertSnapshot(matching: vc, as: .image(on: .iPadMini(.portrait)))
-assertSnapshot(matching: vc, as: .recursiveDescription(on: .iPadMini(.portrait)))
+assertSnapshot(of: vc, as: .image(on: .iPadMini(.portrait)))
+assertSnapshot(of: vc, as: .recursiveDescription(on: .iPadMini(.portrait)))
 ```
 
 > ⚠️ Warning: Snapshots must be compared using the exact same simulator that originally took the reference to avoid discrepancies between images.
@@ -83,7 +83,7 @@ Better yet, SnapshotTesting isn't limited to views and view controllers! There a
 For example, you can snapshot test URL requests (_e.g._, those that your API client prepares).
 
 ``` swift
-assertSnapshot(matching: urlRequest, as: .raw)
+assertSnapshot(of: urlRequest, as: .raw)
 // POST http://localhost:8080/account
 // Cookie: pf_session={"userId":"1"}
 //
@@ -93,14 +93,14 @@ assertSnapshot(matching: urlRequest, as: .raw)
 And you can snapshot test `Encodable` values against their JSON _and_ property list representations.
 
 ``` swift
-assertSnapshot(matching: user, as: .json)
+assertSnapshot(of: user, as: .json)
 // {
 //   "bio" : "Blobbed around the world.",
 //   "id" : 1,
 //   "name" : "Blobby"
 // }
 
-assertSnapshot(matching: user, as: .plist)
+assertSnapshot(of: user, as: .plist)
 // <?xml version="1.0" encoding="UTF-8"?>
 // <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 // <plist version="1.0">
@@ -118,7 +118,7 @@ assertSnapshot(matching: user, as: .plist)
 In fact, _[any](Documentation/Available-Snapshot-Strategies.md#any)_ value can be snapshot-tested by default using its [mirror](https://developer.apple.com/documentation/swift/mirror)!
 
 ``` swift
-assertSnapshot(matching: user, as: .dump)
+assertSnapshot(of: user, as: .dump)
 // ▿ User
 //   - bio: "Blobbed around the world."
 //   - id: 1

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -24,11 +24,14 @@ public var record: Bool {
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
 ///   - timeout: The amount of time a snapshot must be generated in.
-///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
-///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
-///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///     which this function was called.
+///   - testName: The name of the test in which failure occurred. Defaults to the function name of
+///     the test case in which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this
+///     function was called.
 public func assertSnapshot<Value, Format>(
-  matching value: @autoclosure () throws -> Value,
+  of value: @autoclosure () throws -> Value,
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool = false,
@@ -36,10 +39,9 @@ public func assertSnapshot<Value, Format>(
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
-  ) {
-
+) {
   let failure = verifySnapshot(
-    matching: try value(),
+    of: try value(),
     as: snapshotting,
     named: name,
     record: recording,
@@ -63,18 +65,17 @@ public func assertSnapshot<Value, Format>(
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func assertSnapshots<Value, Format>(
-  matching value: @autoclosure () throws -> Value,
+  of value: @autoclosure () throws -> Value,
   as strategies: [String: Snapshotting<Value, Format>],
   record recording: Bool = false,
   timeout: TimeInterval = 5,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
-  ) {
-
+) {
   try? strategies.forEach { name, strategy in
     assertSnapshot(
-      matching: try value(),
+      of: try value(),
       as: strategy,
       named: name,
       record: recording,
@@ -97,18 +98,17 @@ public func assertSnapshots<Value, Format>(
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
 public func assertSnapshots<Value, Format>(
-  matching value: @autoclosure () throws -> Value,
+  of value: @autoclosure () throws -> Value,
   as strategies: [Snapshotting<Value, Format>],
   record recording: Bool = false,
   timeout: TimeInterval = 5,
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
-  ) {
-
+) {
   try? strategies.forEach { strategy in
     assertSnapshot(
-      matching: try value(),
+      of: try value(),
       as: strategy,
       record: recording,
       timeout: timeout,
@@ -124,7 +124,7 @@ public func assertSnapshots<Value, Format>(
 /// Third party snapshot assert helpers can be built on top of this function. Simply invoke `verifySnapshot` with your own arguments, and then invoke `XCTFail` with the string returned if it is non-`nil`. For example, if you want the snapshot directory to be determined by an environment variable, you can create your own assert helper like so:
 ///
 ///     public func myAssertSnapshot<Value, Format>(
-///       matching value: @autoclosure () throws -> Value,
+///       of value: @autoclosure () throws -> Value,
 ///       as snapshotting: Snapshotting<Value, Format>,
 ///       named name: String? = nil,
 ///       record recording: Bool = false,
@@ -136,7 +136,7 @@ public func assertSnapshots<Value, Format>(
 ///
 ///         let snapshotDirectory = ProcessInfo.processInfo.environment["SNAPSHOT_REFERENCE_DIR"]! + "/" + #file
 ///         let failure = verifySnapshot(
-///           matching: value,
+///           of: value,
 ///           as: snapshotting,
 ///           named: name,
 ///           record: recording,
@@ -154,14 +154,19 @@ public func assertSnapshots<Value, Format>(
 ///   - snapshotting: A strategy for serializing, deserializing, and comparing values.
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
-///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved in a directory with the same name as the test file, and that directory will sit inside a directory `__Snapshots__` that sits next to your test file.
+///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved
+///     in a directory with the same name as the test file, and that directory will sit inside a
+///     directory `__Snapshots__` that sits next to your test file.
 ///   - timeout: The amount of time a snapshot must be generated in.
-///   - file: The file in which failure occurred. Defaults to the file name of the test case in which this function was called.
-///   - testName: The name of the test in which failure occurred. Defaults to the function name of the test case in which this function was called.
-///   - line: The line number on which failure occurred. Defaults to the line number on which this function was called.
+///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///     which this function was called.
+///   - testName: The name of the test in which failure occurred. Defaults to the function name of
+///     the test case in which this function was called.
+///   - line: The line number on which failure occurred. Defaults to the line number on which this
+///     function was called.
 /// - Returns: A failure message or, if the value matches, nil.
 public func verifySnapshot<Value, Format>(
-  matching value: @autoclosure () throws -> Value,
+  of value: @autoclosure () throws -> Value,
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool = false,
@@ -170,8 +175,7 @@ public func verifySnapshot<Value, Format>(
   file: StaticString = #file,
   testName: String = #function,
   line: UInt = #line
-  )
-  -> String? {
+) -> String? {
 
     CleanCounterBetweenTestCases.registerIfNeeded()
     let recording = recording || isRecording

--- a/Sources/SnapshotTesting/Internal/Deprecations.swift
+++ b/Sources/SnapshotTesting/Internal/Deprecations.swift
@@ -1,0 +1,104 @@
+import Foundation
+import XCTest
+
+@available(iOS, deprecated: 10000, message: "Use `assertSnapshot(of:…:)` instead.")
+@available(macOS, deprecated: 10000, message: "Use `assertSnapshot(of:…:)` instead.")
+@available(tvOS, deprecated: 10000, message: "Use `assertSnapshot(of:…:)` instead.")
+@available(watchOS, deprecated: 10000, message: "Use `assertSnapshot(of:…:)` instead.")
+public func assertSnapshot<Value, Format>(
+  matching value: @autoclosure () throws -> Value,
+  as snapshotting: Snapshotting<Value, Format>,
+  named name: String? = nil,
+  record recording: Bool = false,
+  timeout: TimeInterval = 5,
+  file: StaticString = #file,
+  testName: String = #function,
+  line: UInt = #line
+) {
+  assertSnapshot(
+    of: try value(),
+    as: snapshotting,
+    named: name,
+    record: recording,
+    timeout: timeout,
+    file: file,
+    testName: testName,
+    line: line
+  )
+}
+
+@available(iOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(macOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(tvOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(watchOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+public func assertSnapshots<Value, Format>(
+  matching value: @autoclosure () throws -> Value,
+  as strategies: [String: Snapshotting<Value, Format>],
+  record recording: Bool = false,
+  timeout: TimeInterval = 5,
+  file: StaticString = #file,
+  testName: String = #function,
+  line: UInt = #line
+) {
+  assertSnapshots(
+    of: try value(),
+    as: strategies,
+    record: recording,
+    timeout: timeout,
+    file: file,
+    testName: testName,
+    line: line
+  )
+}
+
+@available(iOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(macOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(tvOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+@available(watchOS, deprecated: 10000, message: "Use `assertSnapshots(of:…:)` instead.")
+public func assertSnapshots<Value, Format>(
+  matching value: @autoclosure () throws -> Value,
+  as strategies: [Snapshotting<Value, Format>],
+  record recording: Bool = false,
+  timeout: TimeInterval = 5,
+  file: StaticString = #file,
+  testName: String = #function,
+  line: UInt = #line
+) {
+  assertSnapshots(
+    of: try value(),
+    as: strategies,
+    record: recording,
+    timeout: timeout,
+    file: file,
+    testName: testName,
+    line: line
+  )
+}
+
+@available(iOS, deprecated: 10000, message: "Use `verifySnapshot(of:…:)` instead.")
+@available(macOS, deprecated: 10000, message: "Use `verifySnapshot(of:…:)` instead.")
+@available(tvOS, deprecated: 10000, message: "Use `verifySnapshot(of:…:)` instead.")
+@available(watchOS, deprecated: 10000, message: "Use `verifySnapshot(of:…:)` instead.")
+public func verifySnapshot<Value, Format>(
+  matching value: @autoclosure () throws -> Value,
+  as snapshotting: Snapshotting<Value, Format>,
+  named name: String? = nil,
+  record recording: Bool = false,
+  snapshotDirectory: String? = nil,
+  timeout: TimeInterval = 5,
+  file: StaticString = #file,
+  testName: String = #function,
+  line: UInt = #line
+) -> String? {
+  verifySnapshot(
+    of: try value(),
+    as: snapshotting,
+    named: name,
+    record: recording,
+    snapshotDirectory: snapshotDirectory,
+    timeout: timeout,
+    file: file,
+    testName: testName,
+    line: line
+  )
+}

--- a/Tests/SnapshotTestingTests/InlineSnapshotTests.swift
+++ b/Tests/SnapshotTestingTests/InlineSnapshotTests.swift
@@ -505,7 +505,7 @@ func assertSnapshot(source: String, diffable: String, record: Bool = false, file
     }
   }
   """########
-  assertSnapshot(matching: decoratedCode, as: .swift, record: record, file: file, testName: testName, line: line)
+  assertSnapshot(of: decoratedCode, as: .swift, record: record, file: file, testName: testName, line: line)
 }
 
 func assertSnapshot(source: String, diffable: String, diffable2: String, record: Bool = false, file: StaticString = #file, testName: String = #function, line: UInt = #line) {
@@ -529,7 +529,7 @@ func assertSnapshot(source: String, diffable: String, diffable2: String, record:
      }
   }
   """########
-  assertSnapshot(matching: decoratedCode, as: .swift, record: record, file: file, testName: testName, line: line)
+  assertSnapshot(of: decoratedCode, as: .swift, record: record, file: file, testName: testName, line: line)
 }
 
 extension Snapshotting where Value == String, Format == String {

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -34,7 +34,7 @@ final class SnapshotTestingTests: XCTestCase {
   func testAny() {
     struct User { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
-    assertSnapshot(matching: user, as: .dump)
+    assertSnapshot(of: user, as: .dump)
     _assertInlineSnapshot(matching: user, as: .dump, with: """
     ▿ User
       - bio: "Blobbed around the world."
@@ -51,17 +51,17 @@ final class SnapshotTestingTests: XCTestCase {
     let data = try JSONEncoder().encode(user)
     let any = try JSONSerialization.jsonObject(with: data, options: [])
 
-    assertSnapshot(matching: any, as: .json)
+    assertSnapshot(of: any, as: .json)
   }
 
   func testAnySnapshotStringConvertible() {
-    assertSnapshot(matching: "a" as Character, as: .dump, named: "character")
-    assertSnapshot(matching: Data("Hello, world!".utf8), as: .dump, named: "data")
-    assertSnapshot(matching: Date(timeIntervalSinceReferenceDate: 0), as: .dump, named: "date")
-    assertSnapshot(matching: NSObject(), as: .dump, named: "nsobject")
-    assertSnapshot(matching: "Hello, world!", as: .dump, named: "string")
-    assertSnapshot(matching: "Hello, world!".dropLast(8), as: .dump, named: "substring")
-    assertSnapshot(matching: URL(string: "https://www.pointfree.co")!, as: .dump, named: "url")
+    assertSnapshot(of: "a" as Character, as: .dump, named: "character")
+    assertSnapshot(of: Data("Hello, world!".utf8), as: .dump, named: "data")
+    assertSnapshot(of: Date(timeIntervalSinceReferenceDate: 0), as: .dump, named: "date")
+    assertSnapshot(of: NSObject(), as: .dump, named: "nsobject")
+    assertSnapshot(of: "Hello, world!", as: .dump, named: "string")
+    assertSnapshot(of: "Hello, world!".dropLast(8), as: .dump, named: "substring")
+    assertSnapshot(of: URL(string: "https://www.pointfree.co")!, as: .dump, named: "url")
     // Inline
     _assertInlineSnapshot(matching: "a" as Character, as: .dump, with: """
     - "a"
@@ -99,7 +99,7 @@ final class SnapshotTestingTests: XCTestCase {
       subview.leftAnchor.constraint(equalTo: vc.view.leftAnchor),
       subview.rightAnchor.constraint(equalTo: vc.view.rightAnchor),
       ])
-    assertSnapshot(matching: vc, as: .image)
+    assertSnapshot(of: vc, as: .image)
     #endif
   }
 
@@ -110,7 +110,7 @@ final class SnapshotTestingTests: XCTestCase {
       dict: ["c": 3, "a": 1, "b": 2],
       set: [.init(name: "Brandon"), .init(name: "Stephen")]
     )
-    assertSnapshot(matching: set, as: .dump)
+    assertSnapshot(of: set, as: .dump)
     _assertInlineSnapshot(matching: set, as: .dump, with: """
     ▿ DictionarySetContainer
       ▿ dict: 3 key/value pairs
@@ -145,7 +145,7 @@ final class SnapshotTestingTests: XCTestCase {
     }
 
     assertSnapshot(
-      matching: { $0.rotatedLeft },
+      of: { $0.rotatedLeft },
       as: Snapshotting<Direction, String>.func(into: .description)
     )
   }
@@ -164,11 +164,11 @@ final class SnapshotTestingTests: XCTestCase {
     #endif
 
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
-      assertSnapshot(matching: path, as: .image, named: osName)
+      assertSnapshot(of: path, as: .image, named: osName)
     }
 
     if #available(iOS 11.0, OSX 10.13, tvOS 11.0, *) {
-      assertSnapshot(matching: path, as: .elementsDescription, named: osName)
+      assertSnapshot(of: path, as: .elementsDescription, named: osName)
     }
     #endif
   }
@@ -176,7 +176,7 @@ final class SnapshotTestingTests: XCTestCase {
   func testData() {
     let data = Data([0xDE, 0xAD, 0xBE, 0xEF])
 
-    assertSnapshot(matching: data, as: .data)
+    assertSnapshot(of: data, as: .data)
   }
 
   func testEncodable() {
@@ -184,9 +184,9 @@ final class SnapshotTestingTests: XCTestCase {
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
 
     if #available(iOS 11.0, macOS 10.13, tvOS 11.0, *) {
-      assertSnapshot(matching: user, as: .json)
+      assertSnapshot(of: user, as: .json)
     }
-    assertSnapshot(matching: user, as: .plist)
+    assertSnapshot(of: user, as: .plist)
   }
 
   func testMixedViews() {
@@ -208,20 +208,20 @@ final class SnapshotTestingTests: XCTestCase {
 //      view.addSubview(webView)
 //      view.addSubview(skView)
 //
-//      assertSnapshot(matching: view, as: .image, named: platform)
+//      assertSnapshot(of: view, as: .image, named: platform)
 //    }
 //    #endif
   }
 
   func testMultipleSnapshots() {
-    assertSnapshot(matching: [1], as: .dump)
-    assertSnapshot(matching: [1, 2], as: .dump)
+    assertSnapshot(of: [1], as: .dump)
+    assertSnapshot(of: [1, 2], as: .dump)
   }
 
   func testNamedAssertion() {
     struct User { let id: Int, name: String, bio: String }
     let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
-    assertSnapshot(matching: user, as: .dump, named: "named")
+    assertSnapshot(of: user, as: .dump, named: "named")
   }
 
   func testNSBezierPath() {
@@ -229,10 +229,10 @@ final class SnapshotTestingTests: XCTestCase {
     let path = NSBezierPath.heart
 
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
-      assertSnapshot(matching: path, as: .image, named: "macOS")
+      assertSnapshot(of: path, as: .image, named: "macOS")
     }
 
-    assertSnapshot(matching: path, as: .elementsDescription, named: "macOS")
+    assertSnapshot(of: path, as: .elementsDescription, named: "macOS")
     #endif
   }
 
@@ -243,8 +243,8 @@ final class SnapshotTestingTests: XCTestCase {
     button.title = "Push Me"
     button.sizeToFit()
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
-      assertSnapshot(matching: button, as: .image)
-      assertSnapshot(matching: button, as: .recursiveDescription)
+      assertSnapshot(of: button, as: .image)
+      assertSnapshot(of: button, as: .recursiveDescription)
     }
     #endif
   }
@@ -257,8 +257,8 @@ final class SnapshotTestingTests: XCTestCase {
     view.layer?.backgroundColor = NSColor.green.cgColor
     view.layer?.cornerRadius = 5
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
-      assertSnapshot(matching: view, as: .image)
-      assertSnapshot(matching: view, as: .recursiveDescription)
+      assertSnapshot(of: view, as: .image)
+      assertSnapshot(of: view, as: .recursiveDescription)
     }
     #endif
   }
@@ -282,9 +282,9 @@ final class SnapshotTestingTests: XCTestCase {
     #endif
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
       label.text = "Hello."
-      assertSnapshot(matching: label, as: .image(precision: 0.9), named: platform)
+      assertSnapshot(of: label, as: .image(precision: 0.9), named: platform)
       label.text = "Hello"
-      assertSnapshot(matching: label, as: .image(precision: 0.9), named: platform)
+      assertSnapshot(of: label, as: .image(precision: 0.9), named: platform)
     }
     #endif
   }
@@ -300,9 +300,9 @@ final class SnapshotTestingTests: XCTestCase {
     let image = try XCTUnwrap(NSImage(byReferencing: imageURL))
     #endif
 
-    assertSnapshot(matching: image, as: .image(precision: 0.995), named: "exact")
+    assertSnapshot(of: image, as: .image(precision: 0.995), named: "exact")
     if #available(iOS 11.0, tvOS 11.0, macOS 10.13, *) {
-      assertSnapshot(matching: image, as: .image(perceptualPrecision: 0.98), named: "perceptual")
+      assertSnapshot(of: image, as: .image(perceptualPrecision: 0.98), named: "perceptual")
     }
     #endif
   }
@@ -336,7 +336,7 @@ final class SnapshotTestingTests: XCTestCase {
 //      scene.rootNode.addChildNode(omniLightNode)
 //
 //      assertSnapshot(
-//        matching: scene,
+//        of: scene,
 //        as: .image(size: .init(width: 500, height: 500)),
 //        named: platform
 //      )
@@ -355,7 +355,7 @@ final class SnapshotTestingTests: XCTestCase {
 //      scene.addChild(node)
 //
 //      assertSnapshot(
-//        matching: scene,
+//        of: scene,
 //        as: .image(size: .init(width: 50, height: 50)),
 //        named: platform
 //      )
@@ -380,7 +380,7 @@ final class SnapshotTestingTests: XCTestCase {
       }
     }
     let tableViewController = TableViewController()
-    assertSnapshot(matching: tableViewController, as: .image(on: .iPhoneSe))
+    assertSnapshot(of: tableViewController, as: .image(on: .iPhoneSe))
     #endif
   }
 
@@ -401,8 +401,8 @@ final class SnapshotTestingTests: XCTestCase {
       }
     }
     let tableViewController = TableViewController()
-    assertSnapshots(matching: tableViewController, as: ["iPhoneSE-image" : .image(on: .iPhoneSe), "iPad-image" : .image(on: .iPadMini)])
-    assertSnapshots(matching: tableViewController, as: [.image(on: .iPhoneX), .image(on: .iPhoneXsMax)])
+    assertSnapshots(of: tableViewController, as: ["iPhoneSE-image" : .image(on: .iPhoneSe), "iPad-image" : .image(on: .iPadMini)])
+    assertSnapshots(of: tableViewController, as: [.image(on: .iPhoneX), .image(on: .iPhoneXsMax)])
     #endif
   }
 
@@ -466,118 +466,118 @@ final class SnapshotTestingTests: XCTestCase {
       let viewController = MyViewController()
 
       #if os(iOS)
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneSe), named: "iphone-se")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8), named: "iphone-8")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8Plus), named: "iphone-8-plus")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneX), named: "iphone-x")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXr), named: "iphone-xr")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXsMax), named: "iphone-xs-max")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini), named: "ipad-mini")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7), named: "ipad-9-7")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2), named: "ipad-10-2")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5), named: "ipad-pro-10-5")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11), named: "ipad-pro-11")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9), named: "ipad-pro-12-9")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneSe), named: "iphone-se")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8), named: "iphone-8")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8Plus), named: "iphone-8-plus")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneX), named: "iphone-x")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXr), named: "iphone-xr")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXsMax), named: "iphone-xs-max")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini), named: "ipad-mini")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7), named: "ipad-9-7")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2), named: "ipad-10-2")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5), named: "ipad-pro-10-5")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11), named: "ipad-pro-11")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9), named: "ipad-pro-12-9")
 
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhoneSe), named: "iphone-se")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhone8), named: "iphone-8")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhone8Plus), named: "iphone-8-plus")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhoneX), named: "iphone-x")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhoneXr), named: "iphone-xr")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPhoneXsMax), named: "iphone-xs-max")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPadMini), named: "ipad-mini")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPad9_7), named: "ipad-9-7")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPad10_2), named: "ipad-10-2")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPadPro10_5), named: "ipad-pro-10-5")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPadPro11), named: "ipad-pro-11")
-      assertSnapshot(matching: viewController, as: .recursiveDescription(on: .iPadPro12_9), named: "ipad-pro-12-9")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhoneSe), named: "iphone-se")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhone8), named: "iphone-8")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhone8Plus), named: "iphone-8-plus")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhoneX), named: "iphone-x")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhoneXr), named: "iphone-xr")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPhoneXsMax), named: "iphone-xs-max")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPadMini), named: "ipad-mini")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPad9_7), named: "ipad-9-7")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPad10_2), named: "ipad-10-2")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPadPro10_5), named: "ipad-pro-10-5")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPadPro11), named: "ipad-pro-11")
+      assertSnapshot(of: viewController, as: .recursiveDescription(on: .iPadPro12_9), named: "ipad-pro-12-9")
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneSe(.portrait)), named: "iphone-se")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8(.portrait)), named: "iphone-8")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8Plus(.portrait)), named: "iphone-8-plus")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneX(.portrait)), named: "iphone-x")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXr(.portrait)), named: "iphone-xr")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXsMax(.portrait)), named: "iphone-xs-max")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.landscape)), named: "ipad-mini")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.landscape)), named: "ipad-9-7")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.landscape)), named: "ipad-10-2")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.landscape)), named: "ipad-pro-10-5")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.landscape)), named: "ipad-pro-11")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.landscape)), named: "ipad-pro-12-9")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneSe(.portrait)), named: "iphone-se")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8(.portrait)), named: "iphone-8")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8Plus(.portrait)), named: "iphone-8-plus")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneX(.portrait)), named: "iphone-x")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXr(.portrait)), named: "iphone-xr")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXsMax(.portrait)), named: "iphone-xs-max")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.landscape)), named: "ipad-mini")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.landscape)), named: "ipad-9-7")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.landscape)), named: "ipad-10-2")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.landscape)), named: "ipad-pro-10-5")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.landscape)), named: "ipad-pro-11")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.landscape)), named: "ipad-pro-12-9")
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.landscape(splitView: .oneThird))), named: "ipad-mini-33-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.landscape(splitView: .oneHalf))), named: "ipad-mini-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.landscape(splitView: .twoThirds))), named: "ipad-mini-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.portrait(splitView: .oneThird))), named: "ipad-mini-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.portrait(splitView: .twoThirds))), named: "ipad-mini-66-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.landscape(splitView: .oneThird))), named: "ipad-mini-33-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.landscape(splitView: .oneHalf))), named: "ipad-mini-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.landscape(splitView: .twoThirds))), named: "ipad-mini-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.portrait(splitView: .oneThird))), named: "ipad-mini-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.portrait(splitView: .twoThirds))), named: "ipad-mini-66-split-portrait")
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .oneThird))), named: "ipad-9-7-33-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .oneHalf))), named: "ipad-9-7-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .twoThirds))), named: "ipad-9-7-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.portrait(splitView: .oneThird))), named: "ipad-9-7-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.portrait(splitView: .twoThirds))), named: "ipad-9-7-66-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .oneThird))), named: "ipad-9-7-33-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .oneHalf))), named: "ipad-9-7-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.landscape(splitView: .twoThirds))), named: "ipad-9-7-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.portrait(splitView: .oneThird))), named: "ipad-9-7-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.portrait(splitView: .twoThirds))), named: "ipad-9-7-66-split-portrait")
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .oneThird))), named: "ipad-10-2-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .oneHalf))), named: "ipad-10-2-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .twoThirds))), named: "ipad-10-2-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.portrait(splitView: .oneThird))), named: "ipad-10-2-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.portrait(splitView: .twoThirds))), named: "ipad-10-2-66-split-portrait")
-      
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .oneThird))), named: "ipad-pro-10inch-33-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .oneHalf))), named: "ipad-pro-10inch-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .twoThirds))), named: "ipad-pro-10inch-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.portrait(splitView: .oneThird))), named: "ipad-pro-10inch-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.portrait(splitView: .twoThirds))), named: "ipad-pro-10inch-66-split-portrait")
-      
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .oneThird))), named: "ipad-pro-11inch-33-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .oneHalf))), named: "ipad-pro-11inch-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .twoThirds))), named: "ipad-pro-11inch-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.portrait(splitView: .oneThird))), named: "ipad-pro-11inch-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.portrait(splitView: .twoThirds))), named: "ipad-pro-11inch-66-split-portrait")
-      
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .oneThird))), named: "ipad-pro-12inch-33-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .oneHalf))), named: "ipad-pro-12inch-50-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .twoThirds))), named: "ipad-pro-12inch-66-split-landscape")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.portrait(splitView: .oneThird))), named: "ipad-pro-12inch-33-split-portrait")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.portrait(splitView: .twoThirds))), named: "ipad-pro-12inch-66-split-portrait")
-      
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .oneThird))), named: "ipad-10-2-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .oneHalf))), named: "ipad-10-2-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.landscape(splitView: .twoThirds))), named: "ipad-10-2-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.portrait(splitView: .oneThird))), named: "ipad-10-2-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.portrait(splitView: .twoThirds))), named: "ipad-10-2-66-split-portrait")
+
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .oneThird))), named: "ipad-pro-10inch-33-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .oneHalf))), named: "ipad-pro-10inch-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.landscape(splitView: .twoThirds))), named: "ipad-pro-10inch-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.portrait(splitView: .oneThird))), named: "ipad-pro-10inch-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.portrait(splitView: .twoThirds))), named: "ipad-pro-10inch-66-split-portrait")
+
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .oneThird))), named: "ipad-pro-11inch-33-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .oneHalf))), named: "ipad-pro-11inch-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.landscape(splitView: .twoThirds))), named: "ipad-pro-11inch-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.portrait(splitView: .oneThird))), named: "ipad-pro-11inch-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.portrait(splitView: .twoThirds))), named: "ipad-pro-11inch-66-split-portrait")
+
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .oneThird))), named: "ipad-pro-12inch-33-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .oneHalf))), named: "ipad-pro-12inch-50-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.landscape(splitView: .twoThirds))), named: "ipad-pro-12inch-66-split-landscape")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.portrait(splitView: .oneThird))), named: "ipad-pro-12inch-33-split-portrait")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.portrait(splitView: .twoThirds))), named: "ipad-pro-12inch-66-split-portrait")
+
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneSe(.landscape)), named: "iphone-se-alternative")
+        of: viewController, as: .image(on: .iPhoneSe(.landscape)), named: "iphone-se-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhone8(.landscape)), named: "iphone-8-alternative")
+        of: viewController, as: .image(on: .iPhone8(.landscape)), named: "iphone-8-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhone8Plus(.landscape)), named: "iphone-8-plus-alternative")
+        of: viewController, as: .image(on: .iPhone8Plus(.landscape)), named: "iphone-8-plus-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneX(.landscape)), named: "iphone-x-alternative")
+        of: viewController, as: .image(on: .iPhoneX(.landscape)), named: "iphone-x-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneXr(.landscape)), named: "iphone-xr-alternative")
+        of: viewController, as: .image(on: .iPhoneXr(.landscape)), named: "iphone-xr-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneXsMax(.landscape)), named: "iphone-xs-max-alternative")
+        of: viewController, as: .image(on: .iPhoneXsMax(.landscape)), named: "iphone-xs-max-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadMini(.portrait)), named: "ipad-mini-alternative")
+        of: viewController, as: .image(on: .iPadMini(.portrait)), named: "ipad-mini-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPad9_7(.portrait)), named: "ipad-9-7-alternative")
+        of: viewController, as: .image(on: .iPad9_7(.portrait)), named: "ipad-9-7-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPad10_2(.portrait)), named: "ipad-10-2-alternative")
+        of: viewController, as: .image(on: .iPad10_2(.portrait)), named: "ipad-10-2-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro10_5(.portrait)), named: "ipad-pro-10-5-alternative")
+        of: viewController, as: .image(on: .iPadPro10_5(.portrait)), named: "ipad-pro-10-5-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro11(.portrait)), named: "ipad-pro-11-alternative")
+        of: viewController, as: .image(on: .iPadPro11(.portrait)), named: "ipad-pro-11-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro12_9(.portrait)), named: "ipad-pro-12-9-alternative")
+        of: viewController, as: .image(on: .iPadPro12_9(.portrait)), named: "ipad-pro-12-9-alternative")
 
       allContentSizes.forEach { name, contentSize in
           assertSnapshot(
-            matching: viewController,
+            of: viewController,
             as: .image(on: .iPhoneSe, traits: .init(preferredContentSizeCategory: contentSize)),
             named: "iphone-se-\(name)"
           )
       }
       #elseif os(tvOS)
       assertSnapshot(
-        matching: viewController, as: .image(on: .tv), named: "tv")
+        of: viewController, as: .image(on: .tv), named: "tv")
       assertSnapshot(
-        matching: viewController, as: .image(on: .tv4K), named: "tv4k")
+        of: viewController, as: .image(on: .tv4K), named: "tv4k")
       #endif
     }
     #endif
@@ -645,56 +645,56 @@ final class SnapshotTestingTests: XCTestCase {
       let viewController = UITabBarController()
       viewController.setViewControllers([navController], animated: false)
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneSe), named: "iphone-se")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8), named: "iphone-8")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8Plus), named: "iphone-8-plus")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneX), named: "iphone-x")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXr), named: "iphone-xr")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXsMax), named: "iphone-xs-max")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini), named: "ipad-mini")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7), named: "ipad-9-7")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2), named: "ipad-10-2")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5), named: "ipad-pro-10-5")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11), named: "ipad-pro-11")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9), named: "ipad-pro-12-9")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneSe), named: "iphone-se")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8), named: "iphone-8")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8Plus), named: "iphone-8-plus")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneX), named: "iphone-x")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXr), named: "iphone-xr")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXsMax), named: "iphone-xs-max")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini), named: "ipad-mini")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7), named: "ipad-9-7")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2), named: "ipad-10-2")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5), named: "ipad-pro-10-5")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11), named: "ipad-pro-11")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9), named: "ipad-pro-12-9")
 
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneSe(.portrait)), named: "iphone-se")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8(.portrait)), named: "iphone-8")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhone8Plus(.portrait)), named: "iphone-8-plus")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneX(.portrait)), named: "iphone-x")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXr(.portrait)), named: "iphone-xr")
-      assertSnapshot(matching: viewController, as: .image(on: .iPhoneXsMax(.portrait)), named: "iphone-xs-max")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadMini(.landscape)), named: "ipad-mini")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad9_7(.landscape)), named: "ipad-9-7")
-      assertSnapshot(matching: viewController, as: .image(on: .iPad10_2(.landscape)), named: "ipad-10-2")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro10_5(.landscape)), named: "ipad-pro-10-5")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro11(.landscape)), named: "ipad-pro-11")
-      assertSnapshot(matching: viewController, as: .image(on: .iPadPro12_9(.landscape)), named: "ipad-pro-12-9")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneSe(.portrait)), named: "iphone-se")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8(.portrait)), named: "iphone-8")
+      assertSnapshot(of: viewController, as: .image(on: .iPhone8Plus(.portrait)), named: "iphone-8-plus")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneX(.portrait)), named: "iphone-x")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXr(.portrait)), named: "iphone-xr")
+      assertSnapshot(of: viewController, as: .image(on: .iPhoneXsMax(.portrait)), named: "iphone-xs-max")
+      assertSnapshot(of: viewController, as: .image(on: .iPadMini(.landscape)), named: "ipad-mini")
+      assertSnapshot(of: viewController, as: .image(on: .iPad9_7(.landscape)), named: "ipad-9-7")
+      assertSnapshot(of: viewController, as: .image(on: .iPad10_2(.landscape)), named: "ipad-10-2")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro10_5(.landscape)), named: "ipad-pro-10-5")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro11(.landscape)), named: "ipad-pro-11")
+      assertSnapshot(of: viewController, as: .image(on: .iPadPro12_9(.landscape)), named: "ipad-pro-12-9")
 
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneSe(.landscape)), named: "iphone-se-alternative")
+        of: viewController, as: .image(on: .iPhoneSe(.landscape)), named: "iphone-se-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhone8(.landscape)), named: "iphone-8-alternative")
+        of: viewController, as: .image(on: .iPhone8(.landscape)), named: "iphone-8-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhone8Plus(.landscape)), named: "iphone-8-plus-alternative")
+        of: viewController, as: .image(on: .iPhone8Plus(.landscape)), named: "iphone-8-plus-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneX(.landscape)), named: "iphone-x-alternative")
+        of: viewController, as: .image(on: .iPhoneX(.landscape)), named: "iphone-x-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneXr(.landscape)), named: "iphone-xr-alternative")
+        of: viewController, as: .image(on: .iPhoneXr(.landscape)), named: "iphone-xr-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPhoneXsMax(.landscape)), named: "iphone-xs-max-alternative")
+        of: viewController, as: .image(on: .iPhoneXsMax(.landscape)), named: "iphone-xs-max-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadMini(.portrait)), named: "ipad-mini-alternative")
+        of: viewController, as: .image(on: .iPadMini(.portrait)), named: "ipad-mini-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPad9_7(.portrait)), named: "ipad-9-7-alternative")
+        of: viewController, as: .image(on: .iPad9_7(.portrait)), named: "ipad-9-7-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPad10_2(.portrait)), named: "ipad-10-2-alternative")
+        of: viewController, as: .image(on: .iPad10_2(.portrait)), named: "ipad-10-2-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro10_5(.portrait)), named: "ipad-pro-10-5-alternative")
+        of: viewController, as: .image(on: .iPadPro10_5(.portrait)), named: "ipad-pro-10-5-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro11(.portrait)), named: "ipad-pro-11-alternative")
+        of: viewController, as: .image(on: .iPadPro11(.portrait)), named: "ipad-pro-11-alternative")
       assertSnapshot(
-        matching: viewController, as: .image(on: .iPadPro12_9(.portrait)), named: "ipad-pro-12-9-alternative")
+        of: viewController, as: .image(on: .iPadPro12_9(.portrait)), named: "ipad-pro-12-9-alternative")
     }
     #endif
   }
@@ -770,7 +770,7 @@ final class SnapshotTestingTests: XCTestCase {
 
     let viewController = CollectionViewController()
 
-    assertSnapshots(matching: viewController, as: [
+    assertSnapshots(of: viewController, as: [
       "ipad": .image(on: .iPadPro12_9),
       "iphoneSe": .image(on: .iPhoneSe),
       "iphone8": .image(on: .iPhone8),
@@ -789,7 +789,7 @@ final class SnapshotTestingTests: XCTestCase {
 
       allContentSizes.forEach { name, contentSize in
         assertSnapshot(
-          matching: label,
+          of: label,
           as: .image(traits: .init(preferredContentSizeCategory: contentSize)),
           named: "label-\(name)"
         )
@@ -817,7 +817,7 @@ final class SnapshotTestingTests: XCTestCase {
 
     allContentSizes.forEach { name, contentSize in
       assertSnapshot(
-        matching: viewController,
+        of: viewController,
         as: .recursiveDescription(on: .iPhoneSe, traits: .init(preferredContentSizeCategory: contentSize)),
         named: "label-\(name)"
       )
@@ -837,11 +837,11 @@ final class SnapshotTestingTests: XCTestCase {
     #endif
 
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
-      assertSnapshot(matching: path, as: .image, named: osName)
+      assertSnapshot(of: path, as: .image, named: osName)
     }
 
     if #available(iOS 11.0, tvOS 11.0, *) {
-      assertSnapshot(matching: path, as: .elementsDescription, named: osName)
+      assertSnapshot(of: path, as: .elementsDescription, named: osName)
     }
     #endif
   }
@@ -849,8 +849,8 @@ final class SnapshotTestingTests: XCTestCase {
   func testUIView() {
     #if os(iOS)
     let view = UIButton(type: .contactAdd)
-    assertSnapshot(matching: view, as: .image)
-    assertSnapshot(matching: view, as: .recursiveDescription)
+    assertSnapshot(of: view, as: .image)
+    assertSnapshot(of: view, as: .recursiveDescription)
     #endif
   }
 
@@ -917,8 +917,8 @@ final class SnapshotTestingTests: XCTestCase {
       viewDidDisappearExpectation: viewDidDisappearExpectation
     )
 
-    assertSnapshot(matching: viewController, as: .image)
-    assertSnapshot(matching: viewController, as: .image)
+    assertSnapshot(of: viewController, as: .image)
+    assertSnapshot(of: viewController, as: .image)
 
     wait(for: [
       viewDidLoadExpectation,
@@ -937,7 +937,7 @@ final class SnapshotTestingTests: XCTestCase {
     layer.backgroundColor = UIColor.red.cgColor
     layer.borderWidth = 4.0
     layer.borderColor = UIColor.black.cgColor
-    assertSnapshot(matching: layer, as: .image)
+    assertSnapshot(of: layer, as: .image)
     #endif
   }
 
@@ -949,7 +949,7 @@ final class SnapshotTestingTests: XCTestCase {
     gradientLayer.colors = [UIColor.red.cgColor, UIColor.yellow.cgColor]
     gradientLayer.frame = baseLayer.frame
     baseLayer.addSublayer(gradientLayer)
-    assertSnapshot(matching: baseLayer, as: .image)
+    assertSnapshot(of: baseLayer, as: .image)
     #endif
   }
 
@@ -965,7 +965,7 @@ final class SnapshotTestingTests: XCTestCase {
       UINavigationController(rootViewController: UIViewController()),
       UINavigationController(rootViewController: UIViewController())
     ]
-    assertSnapshot(matching: tab, as: .hierarchy)
+    assertSnapshot(of: tab, as: .hierarchy)
     #endif
   }
 
@@ -974,37 +974,37 @@ final class SnapshotTestingTests: XCTestCase {
     get.addValue("pf_session={}", forHTTPHeaderField: "Cookie")
     get.addValue("text/html", forHTTPHeaderField: "Accept")
     get.addValue("application/json", forHTTPHeaderField: "Content-Type")
-    assertSnapshot(matching: get, as: .raw, named: "get")
-    assertSnapshot(matching: get, as: .curl, named: "get-curl")
+    assertSnapshot(of: get, as: .raw, named: "get")
+    assertSnapshot(of: get, as: .curl, named: "get-curl")
 
     var getWithQuery = URLRequest(url: URL(string: "https://www.pointfree.co?key_2=value_2&key_1=value_1&key_3=value_3")!)
     getWithQuery.addValue("pf_session={}", forHTTPHeaderField: "Cookie")
     getWithQuery.addValue("text/html", forHTTPHeaderField: "Accept")
     getWithQuery.addValue("application/json", forHTTPHeaderField: "Content-Type")
-    assertSnapshot(matching: getWithQuery, as: .raw, named: "get-with-query")
-    assertSnapshot(matching: getWithQuery, as: .curl, named: "get-with-query-curl")
+    assertSnapshot(of: getWithQuery, as: .raw, named: "get-with-query")
+    assertSnapshot(of: getWithQuery, as: .curl, named: "get-with-query-curl")
 
     var post = URLRequest(url: URL(string: "https://www.pointfree.co/subscribe")!)
     post.httpMethod = "POST"
     post.addValue("pf_session={\"user_id\":\"0\"}", forHTTPHeaderField: "Cookie")
     post.addValue("text/html", forHTTPHeaderField: "Accept")
     post.httpBody = Data("pricing[billing]=monthly&pricing[lane]=individual".utf8)
-    assertSnapshot(matching: post, as: .raw, named: "post")
-    assertSnapshot(matching: post, as: .curl, named: "post-curl")
-    
+    assertSnapshot(of: post, as: .raw, named: "post")
+    assertSnapshot(of: post, as: .curl, named: "post-curl")
+
     var postWithJSON = URLRequest(url: URL(string: "http://dummy.restapiexample.com/api/v1/create")!)
     postWithJSON.httpMethod = "POST"
     postWithJSON.addValue("application/json", forHTTPHeaderField: "Content-Type")
     postWithJSON.addValue("application/json", forHTTPHeaderField: "Accept")
     postWithJSON.httpBody = Data("{\"name\":\"tammy134235345235\", \"salary\":0, \"age\":\"tammy133\"}".utf8)
-    assertSnapshot(matching: postWithJSON, as: .raw, named: "post-with-json")
-    assertSnapshot(matching: postWithJSON, as: .curl, named: "post-with-json-curl")
+    assertSnapshot(of: postWithJSON, as: .raw, named: "post-with-json")
+    assertSnapshot(of: postWithJSON, as: .curl, named: "post-with-json-curl")
 
     var head = URLRequest(url: URL(string: "https://www.pointfree.co/")!)
     head.httpMethod = "HEAD"
     head.addValue("pf_session={}", forHTTPHeaderField: "Cookie")
-    assertSnapshot(matching: head, as: .raw, named: "head")
-    assertSnapshot(matching: head, as: .curl, named: "head-curl")
+    assertSnapshot(of: head, as: .raw, named: "head")
+    assertSnapshot(of: head, as: .curl, named: "head-curl")
 
     post = URLRequest(url: URL(string: "https://www.pointfree.co/subscribe")!)
     post.httpMethod = "POST"
@@ -1013,7 +1013,7 @@ final class SnapshotTestingTests: XCTestCase {
     post.httpBody = Data("""
                          {"pricing": {"lane": "individual","billing": "monthly"}}
                          """.utf8)
-    _assertInlineSnapshot(matching: post, as: .raw(pretty: true), with: """
+    _assertInlineSnapshot(of: post, as: .raw(pretty: true), with: """
     POST https://www.pointfree.co/subscribe
     Accept: application/json
     Cookie: pf_session={"user_id":"0"}
@@ -1037,7 +1037,7 @@ final class SnapshotTestingTests: XCTestCase {
     webView.loadHTMLString(html, baseURL: nil)
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
       assertSnapshot(
-        matching: webView,
+        of: webView,
         as: .image(size: .init(width: 800, height: 600)),
         named: platform
       )
@@ -1050,17 +1050,17 @@ final class SnapshotTestingTests: XCTestCase {
     var rect = CGRect(x: 0, y: 0, width: 350, height: 0)
     var view = UIView(frame: rect)
     view.backgroundColor = .red
-    assertSnapshot(matching: view, as: .image, named: "noHeight")
-    
+    assertSnapshot(of: view, as: .image, named: "noHeight")
+
     rect = CGRect(x: 0, y: 0, width: 0, height: 350)
     view = UIView(frame: rect)
     view.backgroundColor = .green
-    assertSnapshot(matching: view, as: .image, named: "noWidth")
+    assertSnapshot(of: view, as: .image, named: "noWidth")
 
     rect = CGRect(x: 0, y: 0, width: 0, height: 0)
     view = UIView(frame: rect)
     view.backgroundColor = .blue
-    assertSnapshot(matching: view, as: .image, named: "noWidth.noHeight")
+    assertSnapshot(of: view, as: .image, named: "noWidth.noHeight")
     #endif
   }
 
@@ -1070,7 +1070,7 @@ final class SnapshotTestingTests: XCTestCase {
     let view = UIView(frame: rect)
     view.backgroundColor = .blue
 
-    let failure = verifySnapshot(matching: view, as: .image, named: "notEmptyImage")
+    let failure = verifySnapshot(of: view, as: .image, named: "notEmptyImage")
     XCTAssertNotNil(failure)
     #endif
   }
@@ -1093,7 +1093,7 @@ final class SnapshotTestingTests: XCTestCase {
 
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
       assertSnapshot(
-        matching: stackView,
+        of: stackView,
         as: .image(size: .init(width: 800, height: 600)),
         named: platform
       )
@@ -1119,7 +1119,7 @@ final class SnapshotTestingTests: XCTestCase {
     webView.loadHTMLString(html, baseURL: nil)
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
       assertSnapshot(
-        matching: webView,
+        of: webView,
         as: .image(size: .init(width: 800, height: 600)),
         named: platform
       )
@@ -1149,7 +1149,7 @@ final class SnapshotTestingTests: XCTestCase {
     webView.loadHTMLString(html, baseURL: nil)
     if !ProcessInfo.processInfo.environment.keys.contains("GITHUB_WORKFLOW") {
       assertSnapshot(
-        matching: webView,
+        of: webView,
         as: .image(size: .init(width: 800, height: 600)),
         named: platform
       )
@@ -1175,10 +1175,10 @@ final class SnapshotTestingTests: XCTestCase {
 
     let view = MyView().background(Color.yellow)
 
-    assertSnapshot(matching: view, as: .image(traits: .init(userInterfaceStyle: .light)))
-    assertSnapshot(matching: view, as: .image(layout: .sizeThatFits, traits: .init(userInterfaceStyle: .light)), named: "size-that-fits")
-    assertSnapshot(matching: view, as: .image(layout: .fixed(width: 200.0, height: 100.0), traits: .init(userInterfaceStyle: .light)), named: "fixed")
-    assertSnapshot(matching: view, as: .image(layout: .device(config: .iPhoneSe), traits: .init(userInterfaceStyle: .light)), named: "device")
+    assertSnapshot(of: view, as: .image(traits: .init(userInterfaceStyle: .light)))
+    assertSnapshot(of: view, as: .image(layout: .sizeThatFits, traits: .init(userInterfaceStyle: .light)), named: "size-that-fits")
+    assertSnapshot(of: view, as: .image(layout: .fixed(width: 200.0, height: 100.0), traits: .init(userInterfaceStyle: .light)), named: "fixed")
+    assertSnapshot(of: view, as: .image(layout: .device(config: .iPhoneSe), traits: .init(userInterfaceStyle: .light)), named: "device")
   }
   #endif
 
@@ -1198,10 +1198,10 @@ final class SnapshotTestingTests: XCTestCase {
     }
     let view = MyView().background(Color.yellow)
 
-    assertSnapshot(matching: view, as: .image())
-    assertSnapshot(matching: view, as: .image(layout: .sizeThatFits), named: "size-that-fits")
-    assertSnapshot(matching: view, as: .image(layout: .fixed(width: 300.0, height: 100.0)), named: "fixed")
-    assertSnapshot(matching: view, as: .image(layout: .device(config: .tv)), named: "device")
+    assertSnapshot(of: view, as: .image())
+    assertSnapshot(of: view, as: .image(layout: .sizeThatFits), named: "size-that-fits")
+    assertSnapshot(of: view, as: .image(layout: .fixed(width: 300.0, height: 100.0)), named: "fixed")
+    assertSnapshot(of: view, as: .image(layout: .device(config: .tv)), named: "device")
   }
   #endif
 

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -1013,7 +1013,7 @@ final class SnapshotTestingTests: XCTestCase {
     post.httpBody = Data("""
                          {"pricing": {"lane": "individual","billing": "monthly"}}
                          """.utf8)
-    _assertInlineSnapshot(of: post, as: .raw(pretty: true), with: """
+    _assertInlineSnapshot(matching: post, as: .raw(pretty: true), with: """
     POST https://www.pointfree.co/subscribe
     Accept: application/json
     Cookie: pf_session={"user_id":"0"}

--- a/Tests/SnapshotTestingTests/WaitTests.swift
+++ b/Tests/SnapshotTestingTests/WaitTests.swift
@@ -12,6 +12,6 @@ class WaitTests: XCTestCase {
       value
     }
 
-    assertSnapshot(matching: (), as: .wait(for: 1.5, on: strategy))
+    assertSnapshot(of: (), as: .wait(for: 1.5, on: strategy))
   }
 }


### PR DESCRIPTION
Let's introduce a more streamlined version of `assertSnapshot` that takes an `of` instead of a `matching` parameter:

```diff
-assertSnapshot(matching: value, as: .json)
+assertSnapshot(of: value, as: .json)
```

While `matching` read OK, it is also a little confusing, since it sounds like the value itself is a snapshot, but the helper is really taking a snapshot _of_ the value to be compared.

We'll keep the old version around for a long time as a soft deprecation, but whenever we get close to realizing a 2.0 we can make a harder break.