### PR TITLE
New `canGenerateNewSnapshots` to avoid automatically creating missing ones in CI

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -11,6 +11,10 @@ public var diffTool: String? = nil
 /// Whether or not to record all new references.
 public var isRecording = false
 
+/// Whether or not to create snapshots if they aren't found.
+/// It's recommended to set this to `false` in CI to avoid false negatives if the test is retried.
+public var canGenerateNewSnapshots = true
+
 /// Whether or not to record all new references.
 ///
 /// Due to a name clash in Xcode 12, this has been renamed to `isRecording`.
@@ -256,7 +260,7 @@ public func verifySnapshot<Value, Format>(
       return "Couldn't snapshot value"
     }
 
-    guard !recording, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
+    guard !recording, canGenerateNewSnapshots, fileManager.fileExists(atPath: snapshotFileUrl.path) else {
       try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
       #if !os(Linux) && !os(Windows)
         if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -12,7 +12,7 @@ public var diffTool: String? = nil
 public var isRecording = false
 
 /// Whether or not to create snapshots if they aren't found.
-/// It's recommended to set this to `false` in CI to avoid false negatives if the test is retried.
+/// It's recommended to set this to `false` in CI to avoid false positives if the test is retried.
 public var canGenerateNewSnapshots = true
 
 /// Whether or not to record all new references.

--- a/Sources/SnapshotTesting/Documentation.docc/SnapshotTesting.md
+++ b/Sources/SnapshotTesting/Documentation.docc/SnapshotTesting.md
@@ -18,6 +18,7 @@ Powerfully flexible snapshot testing.
 ### Configuration
 
 - ``isRecording``
+- ``canGenerateNewSnapshots``
 - ``diffTool``
 
 ### Deprecations


### PR DESCRIPTION
Fixes #748.