### PR TITLE
Escape carriage returns explicitly

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -387,7 +387,11 @@ private final class SnapshotRewriter: SyntaxRewriter {
             segments: [
               .stringSegment(
                 StringSegmentSyntax(
-                  content: .stringSegment(snapshot.actual.indenting(with: leadingIndent))
+                  content: .stringSegment(
+                    snapshot.actual
+                      .replacingOccurrences(of: "\r", with: #"\\#(delimiter)r"#)
+                      .indenting(with: leadingIndent)
+                  )
                 )
               )
             ],

--- a/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
+++ b/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
@@ -234,14 +234,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
   }
 
   func testCarriageReturnInlineSnapshot() {
-    let string = "This is a line\r\nAnd this is a line\r\n"
-    var request = URLRequest(url: URL(string: "https://www.example.com")!)
-    request.httpMethod = "POST"
-    request.httpBody = string.data(using: .utf8)!
-    assertInlineSnapshot(of: request, as: .raw) {
+    assertInlineSnapshot(of: "This is a line\r\nAnd this is a line\r\n", as: .lines) {
       """
-      POST https://www.example.com
-
       This is a line\r
       And this is a line\r
 
@@ -250,14 +244,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
   }
 
   func testCarriageReturnRawInlineSnapshot() {
-    let string = "\"\"\"#This is a line\r\nAnd this is a line\r\n"
-    var request = URLRequest(url: URL(string: "https://www.example.com")!)
-    request.httpMethod = "POST"
-    request.httpBody = string.data(using: .utf8)!
-    assertInlineSnapshot(of: request, as: .raw) {
+    assertInlineSnapshot(of: "\"\"\"#This is a line\r\nAnd this is a line\r\n", as: .lines) {
       ##"""
-      POST https://www.example.com
-
       """#This is a line\##r
       And this is a line\##r
 

--- a/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
+++ b/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
@@ -225,10 +225,10 @@ final class InlineSnapshotTestingTests: XCTestCase {
 
     withDependencies {
       assertInlineSnapshot(of: "Hello", as: .dump) {
-          """
-          - "Hello"
+        """
+        - "Hello"
 
-          """
+        """
       }
     }
   }

--- a/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
+++ b/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
@@ -225,11 +225,43 @@ final class InlineSnapshotTestingTests: XCTestCase {
 
     withDependencies {
       assertInlineSnapshot(of: "Hello", as: .dump) {
-        """
-        - "Hello"
+          """
+          - "Hello"
 
-        """
+          """
       }
+    }
+  }
+
+  func testCarriageReturnInlineSnapshot() {
+    let string = "This is a line\r\nAnd this is a line\r\n"
+    var request = URLRequest(url: URL(string: "https://www.example.com")!)
+    request.httpMethod = "POST"
+    request.httpBody = string.data(using: .utf8)!
+    assertInlineSnapshot(of: request, as: .raw) {
+      """
+      POST https://www.example.com
+
+      This is a line\r
+      And this is a line\r
+
+      """
+    }
+  }
+
+  func testCarriageReturnRawInlineSnapshot() {
+    let string = "\"\"\"#This is a line\r\nAnd this is a line\r\n"
+    var request = URLRequest(url: URL(string: "https://www.example.com")!)
+    request.httpMethod = "POST"
+    request.httpBody = string.data(using: .utf8)!
+    assertInlineSnapshot(of: request, as: .raw) {
+      ##"""
+      POST https://www.example.com
+
+      """#This is a line\##r
+      And this is a line\##r
+
+      """##
     }
   }
 }


### PR DESCRIPTION
Either Xcode or SwiftSyntax is stripping the carriage return out of the snapshot, but either way we should probably explicitly escape them for visibility.

Fixes #771.