### PR TITLE
Added an isOpaque parameter to view strategies to allow for transparent snapshots

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -964,6 +964,7 @@
     func snapshotView(
       config: ViewImageConfig,
       drawHierarchyInKeyWindow: Bool,
+      isOpaque: Bool,
       traits: UITraitCollection,
       view: UIView,
       viewController: UIViewController
@@ -987,6 +988,11 @@
           addImagesForRenderedViews(view).sequence().run { views in
             callback(
               renderer(bounds: view.bounds, for: traits).image { ctx in
+                if isOpaque == false {
+                  UIColor.clear.setFill()
+                  ctx.fill(view.bounds)
+                }
+                
                 if drawHierarchyInKeyWindow {
                   view.drawHierarchy(in: view.bounds, afterScreenUpdates: true)
                 } else {

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -38,6 +38,7 @@
       ///   - traits: A trait collection override.
       public static func image(
         drawHierarchyInKeyWindow: Bool = false,
+        isOpaque: Bool = true,
         precision: Float = 1,
         perceptualPrecision: Float = 1,
         layout: SwiftUISnapshotLayout = .sizeThatFits,
@@ -72,6 +73,9 @@
             )
           } else {
             let hostingController = UIHostingController.init(rootView: view)
+            if isOpaque == false {
+              hostingController.view.backgroundColor = .clear
+            }
 
             let maxSize = CGSize(width: 0.0, height: 0.0)
             config.size = hostingController.sizeThatFits(in: maxSize)
@@ -82,6 +86,7 @@
           return snapshotView(
             config: config,
             drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+            isOpaque: isOpaque,
             traits: traits,
             view: controller.view,
             viewController: controller

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -22,6 +22,7 @@
     ///   - traits: A trait collection override.
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
+      isOpaque: Bool = true,
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
@@ -36,6 +37,7 @@
         snapshotView(
           config: .init(safeArea: .zero, size: size ?? view.frame.size, traits: .init()),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+          isOpaque: isOpaque,
           traits: traits,
           view: view,
           viewController: .init()

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -20,6 +20,7 @@
     ///   - traits: A trait collection override.
     public static func image(
       on config: ViewImageConfig,
+      isOpaque: Bool = true,
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
@@ -35,6 +36,7 @@
           config: size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) }
             ?? config,
           drawHierarchyInKeyWindow: false,
+          isOpaque: isOpaque,
           traits: traits,
           view: viewController.view,
           viewController: viewController
@@ -57,6 +59,7 @@
     ///   - traits: A trait collection override.
     public static func image(
       drawHierarchyInKeyWindow: Bool = false,
+      isOpaque: Bool = true,
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
@@ -71,6 +74,7 @@
         snapshotView(
           config: .init(safeArea: .zero, size: size, traits: traits),
           drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+          isOpaque: isOpaque,
           traits: traits,
           view: viewController.view,
           viewController: viewController


### PR DESCRIPTION
This PR allows you to capture transparent screenshots. Previously, all transparent bits would get replaced with white, and so this could be a breaking change for existing tests, and so is gated behind an `isOpaque` parameter that is true by default, thus retaining the old behaviour