### PR TITLE
Avoid additional trailing closure offset crash

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -566,15 +566,15 @@ private final class SnapshotVisitor: SyntaxVisitor {
       }
 
     case 1...:
-      self.trailingClosureLine =
-        functionCallExpr.additionalTrailingClosures[
-          functionCallExpr.additionalTrailingClosures.index(
-            functionCallExpr.additionalTrailingClosures.startIndex,
-            offsetBy: centeredTrailingClosureOffset - 1
-          )
-        ]
-        .startLocation(converter: self.sourceLocationConverter)
-        .line
+      let index = functionCallExpr.additionalTrailingClosures.index(
+        functionCallExpr.additionalTrailingClosures.startIndex,
+        offsetBy: centeredTrailingClosureOffset - 1
+      )
+      if centeredTrailingClosureOffset - 1 < functionCallExpr.additionalTrailingClosures.count {
+        self.trailingClosureLine = functionCallExpr.additionalTrailingClosures[index]
+          .startLocation(converter: self.sourceLocationConverter)
+          .line
+      }
     default:
       break
     }


### PR DESCRIPTION
A MacroTesting bug report encountered an index crash:

https://github.com/pointfreeco/swift-macro-testing/issues/6

Even when updating to `index(_:offsetBy:limitedBy:)`, the crash remained, so I've resorted to more explicit limiting math. This seems to fix the crash.