### PR TITLE
Write to snapshot state before failing

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -73,6 +73,19 @@ public func assertInlineSnapshot<Value>(
     }
     guard !isRecording, let expected = expected?()
     else {
+      // NB: Write snapshot state before calling `XCTFail` in case `continueAfterFailure = false`
+      inlineSnapshotState[File(path: file), default: []].append(
+        InlineSnapshot(
+          expected: expected?(),
+          actual: actual,
+          wasRecording: isRecording,
+          syntaxDescriptor: syntaxDescriptor,
+          function: "\(function)",
+          line: line,
+          column: column
+        )
+      )
+
       var failure: String
       if syntaxDescriptor.trailingClosureLabel
         == InlineSnapshotSyntaxDescriptor.defaultTrailingClosureLabel
@@ -96,17 +109,6 @@ public func assertInlineSnapshot<Value>(
         """,
         file: file,
         line: line
-      )
-      inlineSnapshotState[File(path: file), default: []].append(
-        InlineSnapshot(
-          expected: expected?(),
-          actual: actual,
-          wasRecording: isRecording,
-          syntaxDescriptor: syntaxDescriptor,
-          function: "\(function)",
-          line: line,
-          column: column
-        )
       )
       return
     }


### PR DESCRIPTION
XCTest test cases can be configured with `continueAfterFailure = false`, and in fact UI tests are configured with this by default, but in these cases inline snapshots will never be written because the failure aborts the test before we write to the snapshot state.

This commit reorders things to fix the problem.