### PR TITLE
Transform `assertCustomInline()` to `assertCustomInline { ... }`

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -502,6 +502,18 @@ private final class SnapshotRewriter: SyntaxRewriter {
         fatalError()
       }
     }
+
+    if
+      functionCallExpr.arguments.isEmpty,
+      functionCallExpr.trailingClosure != nil,
+      functionCallExpr.leftParen != nil,
+      functionCallExpr.rightParen != nil
+    {
+      functionCallExpr.leftParen = nil
+      functionCallExpr.rightParen = nil
+      functionCallExpr.calledExpression.trailingTrivia = .space
+    }
+
     return ExprSyntax(functionCallExpr)
   }
 }

--- a/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
+++ b/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
@@ -103,6 +103,37 @@ final class InlineSnapshotTestingTests: XCTestCase {
     )
   }
 
+  func testArgumentlessInlineSnapshot() {
+    func assertArgumentlessInlineSnapshot(
+      expected: (() -> String)? = nil,
+      file: StaticString = #filePath,
+      function: StaticString = #function,
+      line: UInt = #line,
+      column: UInt = #column
+    ) {
+      assertInlineSnapshot(
+        of: "Hello",
+        as: .dump,
+        syntaxDescriptor: InlineSnapshotSyntaxDescriptor(
+          trailingClosureLabel: "is",
+          trailingClosureOffset: 1
+        ),
+        matches: expected,
+        file: file,
+        function: function,
+        line: line,
+        column: column
+      )
+    }
+
+    assertArgumentlessInlineSnapshot {
+      """
+      - "Hello"
+
+      """
+    }
+  }
+
   func testMultipleInlineSnapshots() {
     func assertResponse(
       of url: () -> String,


### PR DESCRIPTION
Right now we preserve the `()`, which leads to atypical Swift code, like:

```swift
assertCustomInline() {
  """
  ...
  """
}
```