### PR TITLE
Add more information around `drawHierarchyInKeyWindow`

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -25,6 +25,14 @@
 
       /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.
       ///
+      /// If you are using a host application we recommend that you set
+      /// `drawHierarchyInKeyWindow` to `true` to capture the most accurate
+      /// snapshots. Setting it to `false` can result in snapshots that don't look
+      /// exactly like your user interface. Examples we've seen are tab bars that
+      /// don't have the right color for their unselected tabs, lists that have
+      /// corner radii on every row instead of only on the top and bottom rows,
+      /// and rounded rectangles that have rendering artifacts. 
+      ///
       /// - Parameters:
       ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render
       ///     `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -9,6 +9,14 @@
 
     /// A snapshot strategy for comparing views based on pixel equality.
     ///
+    /// If you are using a host application we recommend that you set
+    /// `drawHierarchyInKeyWindow` to `true` to capture the most accurate
+    /// snapshots. Setting it to `false` can result in snapshots that don't look
+    /// exactly like your user interface. Examples we've seen are tab bars that
+    /// don't have the right color for their unselected tabs, lists that have
+    /// corner radii on every row instead of only on the top and bottom rows,
+    /// and rounded rectangles that have rendering artifacts. 
+    ///
     /// - Parameters:
     ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render
     ///     `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -9,6 +9,18 @@
 
     /// A snapshot strategy for comparing view controller views based on pixel equality.
     ///
+    /// This strategy trades image accuracy for the flexibility to use this
+    /// strategy inside of framework and package test targets. This can result
+    /// in snapshots that don't look exactly like the user interface they are
+    /// snapshotting. Examples we've seen are tab bars that don't have the right
+    /// color for their unselected tabs, lists that have corner radii on every
+    /// row instead of only on the top and bottom rows, and rounded rectangles
+    /// that have rendering artifacts.
+    ///
+    /// For more accurate snapshots use a host application for your tests with
+    /// the ``image(drawHierarchyInKeyWindow:precision:perceptualPrecision:size:traits:)``
+    /// method and pass `true` to the `drawHierarchyInKeyWindow` parameter.
+    ///
     /// - Parameters:
     ///   - config: A set of device configuration settings.
     ///   - precision: The percentage of pixels that must match.
@@ -43,6 +55,14 @@
     }
 
     /// A snapshot strategy for comparing view controller views based on pixel equality.
+    ///
+    /// If you are using a host application we recommend that you set
+    /// `drawHierarchyInKeyWindow` to `true` to capture the most accurate
+    /// snapshots. Setting it to `false` can result in snapshots that don't look
+    /// exactly like your user interface. Examples we've seen are tab bars that
+    /// don't have the right color for their unselected tabs, lists that have
+    /// corner radii on every row instead of only on the top and bottom rows,
+    /// and rounded rectangles that have rendering artifacts.
     ///
     /// - Parameters:
     ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render


### PR DESCRIPTION
This pull request proposes additional documentation for image-based view snapshots around hosted tests and `drawHierarchyInKeyWindow`.  I've been using the snapshot testing library for over a year and hosted tests for the last nine months, and I did not realize that I needed to set `drawHierarchyInKeyWindow` to `true` to resolve some rendering issues I was seeing. I'm hoping this documentation will help future folks to use the proper tool more quickly than I did.