### PR TITLE
Adds drawHierarchyInKeyWindow parameter

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -11,6 +11,9 @@
     ///
     /// - Parameters:
     ///   - config: A set of device configuration settings.
+    ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render
+    ///     `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your
+    ///     tests and will _not_ work for framework test targets.
     ///   - precision: The percentage of pixels that must match.
     ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a
     ///     match. 98-99% mimics
@@ -20,6 +23,7 @@
     ///   - traits: A trait collection override.
     public static func image(
       on config: ViewImageConfig,
+      drawHierarchyInKeyWindow: Bool = false,
       precision: Float = 1,
       perceptualPrecision: Float = 1,
       size: CGSize? = nil,
@@ -34,7 +38,7 @@
         snapshotView(
           config: size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) }
             ?? config,
-          drawHierarchyInKeyWindow: false,
+          drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
           traits: traits,
           view: viewController.view,
           viewController: viewController


### PR DESCRIPTION
### What does this Pull Request do?

Adds the `drawHeirarchyInKeyWindow` parameter to the `image` method in `UIViewController.swift` file.
```swift 
    public static func image(
      on config: ViewImageConfig,
      drawHierarchyInKeyWindow: Bool = false,
      precision: Float = 1,
      perceptualPrecision: Float = 1,
      size: CGSize? = nil,
      traits: UITraitCollection = .init()
    )
      -> Snapshotting
    {

      return SimplySnapshotting.image(
        precision: precision, perceptualPrecision: perceptualPrecision, scale: traits.displayScale
      ).asyncPullback { viewController in
        snapshotView(
          config: size.map { .init(safeArea: config.safeArea, size: $0, traits: config.traits) }
            ?? config,
          drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
          traits: traits,
          view: viewController.view,
          viewController: viewController
        )
      }
    }
```

We tried to extend the function in our project but got errors because `snapshotView` is  private!

#### Use case: 

Noticed other methods similar to this one had the `drawHierarchyInKeyWindow` parameter. For our use case we are using UIViewControllers as containers to SwiftUI views that contain UIVisualEffects.  Without this parameter the UIVisualEffect would appear transparent in the snapshots. 

Is this something we can add? Thanks!