### PR TITLE
Exclude newlines from indent string in SnapshotRewriter.

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -389,7 +389,7 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       self.indent = String(
         sourceLocationConverter.sourceLines
           .first(where: { $0.first?.isWhitespace == true && $0 != "\n" })?
-          .prefix(while: { $0.isWhitespace })
+          .prefix(while: { $0.isWhitespace && $0 != "\n" })
           ?? "    "
       )
       self.snapshots = snapshots

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -388,8 +388,8 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       self.wasRecording = snapshots.first?.wasRecording ?? isRecording
       self.indent = String(
         sourceLocationConverter.sourceLines
-          .first(where: { $0.first?.isWhitespace == true && $0 != "\n" })?
-          .prefix(while: { $0.isWhitespace && $0 != "\n" })
+            .first(where: { $0.first?.isWhitespace == true && $0.trimmingCharacters(in: .whitespacesAndNewlines) != "" })?
+            .prefix(while: { $0.isWhitespace && !$0.isNewline })
           ?? "    "
       )
       self.snapshots = snapshots

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -388,8 +388,8 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       self.wasRecording = snapshots.first?.wasRecording ?? isRecording
       self.indent = String(
         sourceLocationConverter.sourceLines
-            .first(where: { $0.first?.isWhitespace == true && $0.trimmingCharacters(in: .whitespacesAndNewlines) != "" })?
-            .prefix(while: { $0.isWhitespace && !$0.isNewline })
+          .first(where: { $0.first?.isWhitespace == true && $0.trimmingCharacters(in: .whitespacesAndNewlines) != "" })?
+          .prefix(while: { $0.isWhitespace && !$0.isNewline })
           ?? "    "
       )
       self.snapshots = snapshots


### PR DESCRIPTION
This PR fixes an issue that was first raised in pointfreeco/swift-macro-testing#11. I mysteriously hit this same issue of extra newlines in the generated expansion while editing a macro test source file that was previously working. It was a real head scratcher, but I was able to track it down.

The underlying cause is the algorithm to determine the default indentation level in `SnapshotRewriter`.  The code looks for the first use of leading whitespace in the source file, and then uses that to determine the indention size.  However, it didn't account for the case where the first use of leading whitespace, may be an empty "indented line" followed by a newline, with no non-whitespace characters.

A trivial example would be:

```swift
import Foundation
import InlineSnapshotTesting
import SnapshotTesting
import XCTest

final class WhitespaceTests: XCTestCase {
  
  func testInlineSnapshot() {
    assertInlineSnapshot(of: ["Hello", "World"], as: .dump)
  }
}
```

In the above example there are two spaces after the class declaration and before the function declaration which causes the indention string to be calculated as `"  \n"` instead of the expected `"  "`, resulting in extra newlines being introduced in the generated output.  When run the following is produced:

```swift
import Foundation
import InlineSnapshotTesting
import SnapshotTesting
import XCTest

final class WhitespaceTests: XCTestCase {
  
  func testInlineSnapshot() {
    assertInlineSnapshot(of: ["Hello", "World"], as: .dump) {
      
"""

▿ 2 elements

  - "Hello"

  - "World"


"""
    }
  }
}
```

With this PR, the correct output is now produced:

```swift
import Foundation
import InlineSnapshotTesting
import SnapshotTesting
import XCTest

final class WhitespaceTests: XCTestCase {
  
  func testInlineSnapshot() {
    assertInlineSnapshot(of: ["Hello", "World"], as: .dump) {
      """
      ▿ 2 elements
        - "Hello"
        - "World"

      """
    }
  }
}
```