### PR TITLE
Remove deprecated UIGraphicsBeginImageContextWithOptions

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -182,12 +182,13 @@
     let width = max(old.size.width, new.size.width)
     let height = max(old.size.height, new.size.height)
     let scale = max(old.scale, new.scale)
-    UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: height), true, scale)
-    new.draw(at: .zero)
-    old.draw(at: .zero, blendMode: .difference, alpha: 1)
-    let differenceImage = UIGraphicsGetImageFromCurrentImageContext()!
-    UIGraphicsEndImageContext()
-    return differenceImage
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = scale
+    format.opaque = true
+    return UIGraphicsImageRenderer(size: CGSize(width: width, height: height), format: format).image { _ in
+      new.draw(at: .zero)
+      old.draw(at: .zero, blendMode: .difference, alpha: 1)
+    }
   }
 #endif
 


### PR DESCRIPTION
As of iOS 17, `UIGraphicsBeginImageContextWithOptions` [has been deprecated](https://developer.apple.com/documentation/uikit/1623912-uigraphicsbeginimagecontextwitho), and causes apps built with Xcode 15 to crash. The suggested fix is to use `UIGraphicsImageRenderer`, which this PR implements.