### PR TITLE
Fix indentation parsing

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -388,8 +388,8 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       self.wasRecording = snapshots.first?.wasRecording ?? isRecording
       self.indent = String(
         sourceLocationConverter.sourceLines
-          .first(where: { $0.first?.isWhitespace == true && $0 != "\n" })?
-          .prefix(while: { $0.isWhitespace })
+          .first { $0.first?.isWhitespace == true && $0.contains { !$0.isWhitespace } }?
+          .prefix { $0.isWhitespace }
           ?? "    "
       )
       self.snapshots = snapshots


### PR DESCRIPTION
Inline snapshot testing attempts to figure out the indentation width of a file by finding the first line with whitespace and grabbing the prefix of whitespace. While this works fine if you trim whitespace from whitespace-only lines, it breaks if you do not, because a line of the form:

```
"    \n"
```

Will currently match in its entirety and incorporate the newline into the indentation.

This PR fixes this by picking the first indented line that contains non-whitespace characters, instead.