### PR TITLE
Register test observer in main queue

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -371,15 +371,21 @@ func sanitizePathComponent(_ string: String) -> String {
 // We need to clean counter between tests executions in order to support test-iterations.
 private class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
   private static var registered = false
-  private static var registerQueue = DispatchQueue(
-    label: "co.pointfree.SnapshotTesting.testObserver")
 
   static func registerIfNeeded() {
-    registerQueue.sync {
-      if !registered {
-        registered = true
-        XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
+    if Thread.isMainThread {
+      doRegisterIfNeeded()
+    } else {
+      DispatchQueue.main.sync { 
+        doRegisterIfNeeded()
       }
+    }
+  }
+
+  private static func doRegisterIfNeeded() {
+    if !registered {
+      registered = true
+      XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
     }
   }
 


### PR DESCRIPTION
Fixes a crash when calling [XCTestObservationCenter addTestObserver:] that would fail an assertion: 'Test observers can only be registered and unregistered on the main thread.'

Fixes: https://github.com/pointfreeco/swift-snapshot-testing/issues/661