### PR TITLE
Add `diffToolBuilder` for building complex diff command messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ targets: [
   - **Custom diff tool integration**. Configure failure messages to print diff commands for
     [Kaleidoscope](https://kaleidoscope.app) or your diff tool of choice.
     ``` swift
-    SnapshotTesting.diffToolBuilder = { "ksdiff \($0) \($1)" }
+    SnapshotTesting.diffToolCommand = { "ksdiff \($0) \($1)" }
     ```
 
 [available-strategies]: https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing/main/documentation/snapshottesting/snapshotting

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ targets: [
   - **`Codable` support**. Snapshot encodable data structures into their JSON and property list
     representations.
   - **Custom diff tool integration**. Configure failure messages to print diff commands for
-    [Kaleidoscope](https://kaleidoscope.app) (or your diff tool of choice).
+    [Kaleidoscope](https://kaleidoscope.app) or your diff tool of choice.
     ``` swift
-    SnapshotTesting.diffTool = "ksdiff"
+    SnapshotTesting.diffToolBuilder = { "ksdiff \($0) \($1)" }
     ```
 
 [available-strategies]: https://swiftpackageindex.com/pointfreeco/swift-snapshot-testing/main/documentation/snapshottesting/snapshotting

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -1,20 +1,28 @@
 import XCTest
 
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted
-/// into a terminal.
+/// into a terminal. For more complex difftool needs, see `diffToolCommand`.
 ///
 /// ```swift
 /// diffTool = "ksdiff"
 /// ```
-public var diffTool: String? = nil
+public var diffTool: String? {
+    get { diffToolCommand?("", "").trimmingCharacters(in: .whitespaces) }
+    set {
+        diffToolCommand = newValue.map { value in
+            { [value, $0, $1].joined(separator: " ") }
+        }
+    }
+}
 
 /// Enhances failure messages with a diff tool expression created by the closure, such as an clickable
-/// URL or a complex command.
+/// URL or a complex command. The closure will receive the existing screenshot path and the failed
+/// screenshot path as arguments.
 ///
 /// ```swift
-/// diffToolBuilder = { "compare \"\($0.path)\" \"\($1.path)\" png: | open -f -a Preview.app" }
+/// diffToolCommand = { "compare \"\($0)\" \"\($1)\" png: | open -f -a Preview.app" }
 /// ```
-public var diffToolBuilder: ((URL, URL) -> String)?
+public var diffToolCommand: ((String, String) -> String)?
 
 /// Whether or not to record all new references.
 public var isRecording = false
@@ -331,11 +339,8 @@ public func verifySnapshot<Value, Format>(
       #endif
     }
 
-    let diffToolMessage = diffToolBuilder?(snapshotFileUrl, failedSnapshotFileUrl) ??
-      (diffTool
-        .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" })
     let diffMessage =
-      diffToolMessage
+      diffToolCommand?(snapshotFileUrl.path, failedSnapshotFileUrl.path)
         ?? """
         @\(minus)
         "\(snapshotFileUrl.absoluteString)"

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -8,6 +8,14 @@ import XCTest
 /// ```
 public var diffTool: String? = nil
 
+/// Enhances failure messages with a diff tool expression created by the closure, such as an clickable
+/// URL or a complex command.
+///
+/// ```swift
+/// diffToolBuilder = { "compare \"\($0.path)\" \"\($1.path)\" png: | open -f -a Preview.app" }
+/// ```
+public var diffToolBuilder: ((URL, URL) -> String)?
+
 /// Whether or not to record all new references.
 public var isRecording = false
 
@@ -323,9 +331,11 @@ public func verifySnapshot<Value, Format>(
       #endif
     }
 
+    let diffToolMessage = diffToolBuilder?(snapshotFileUrl, failedSnapshotFileUrl) ??
+      (diffTool
+        .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" })
     let diffMessage =
-      diffTool
-      .map { "\($0) \"\(snapshotFileUrl.path)\" \"\(failedSnapshotFileUrl.path)\"" }
+      diffToolMessage
         ?? """
         @\(minus)
         "\(snapshotFileUrl.absoluteString)"


### PR DESCRIPTION
This PR adds `SnapshotTesting.diffToolBuilder` closure for building complex diff tool command messages or clickable urls in Xcode. It takes the existing and the failure snapshot as arguments, and thus complex commands which are not just prefixed with the existing `diffTool` can be created. 

For instance, to open [Differati](https://github.com/js/Differati) from a clickable link in Xcode the following `diffToolBuilder` closure can be provided, which URL encodes the paths (in case they contain spaces etc) and builds an url openable by the app:
```swift
SnapshotTesting.diffToolBuilder = { existing, failed in
    func encode(_ path: String) -> String {
        path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
    }
    return "differati://show?old=\(encode(existing.path))&new=\(encode(failed.path))"
}
```

Which gives us an Xcode test failure bubble like this, with a clickable url that takes us directly into the diffing app:
![image](https://github.com/pointfreeco/swift-snapshot-testing/assets/23626/9f374199-93dc-465e-9374-e689695753a5)

Or it can be used to build a complex diff command with the path arguments aren't simply a suffix, as requested in #780:
```swift
SnapshotTesting.diffToolBuilder = { "compare \"\($0.path)\" \"\($1.path)\" png: | open -f -a Preview.app" }
```