### PR TITLE
Ability to remove inline snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
     strategy:
       matrix:
         swift:
-          - "5.8"
+          - "5.9.1"
 
     name: Windows (Swift ${{ matrix.swift }})
-    runs-on: windows-2019
+    runs-on: windows-latest
 
     steps:
       - uses: compnerd/gha-setup-swift@main
@@ -59,6 +59,6 @@ jobs:
           git config --global core.autocrlf false
           git config --global core.eol lf
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: swift build
       - run: swift test

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -32,7 +32,7 @@ import Foundation
   ///   - column: The column where the assertion occurs. The default is the line column you call
   ///     this function.
   public func assertInlineSnapshot<Value>(
-    of value: @autoclosure () throws -> Value,
+    of value: @autoclosure () throws -> Value?,
     as snapshotting: Snapshotting<Value, String>,
     message: @autoclosure () -> String = "",
     record isRecording: Bool = isRecording,
@@ -46,41 +46,44 @@ import Foundation
   ) {
     let _: Void = installTestObserver
     do {
-      var actual: String!
+      var actual: String?
       let expectation = XCTestExpectation()
-      try snapshotting.snapshot(value()).run {
-        actual = $0
-        expectation.fulfill()
-      }
-      switch XCTWaiter.wait(for: [expectation], timeout: timeout) {
-      case .completed:
-        break
-      case .timedOut:
-        XCTFail(
-          """
-          Exceeded timeout of \(timeout) seconds waiting for snapshot.
+      if let value = try value() {
+        snapshotting.snapshot(value).run {
+          actual = $0
+          expectation.fulfill()
+        }
+        switch XCTWaiter.wait(for: [expectation], timeout: timeout) {
+        case .completed:
+          break
+        case .timedOut:
+          XCTFail(
+            """
+            Exceeded timeout of \(timeout) seconds waiting for snapshot.
 
-          This can happen when an asynchronously loaded value (like a network response) has not \
-          loaded. If a timeout is unavoidable, consider setting the "timeout" parameter of
-          "assertInlineSnapshot" to a higher value.
-          """,
-          file: file,
-          line: line
-        )
-        return
-      case .incorrectOrder, .interrupted, .invertedFulfillment:
-        XCTFail("Couldn't snapshot value", file: file, line: line)
-        return
-      @unknown default:
-        XCTFail("Couldn't snapshot value", file: file, line: line)
-        return
+            This can happen when an asynchronously loaded value (like a network response) has not \
+            loaded. If a timeout is unavoidable, consider setting the "timeout" parameter of
+            "assertInlineSnapshot" to a higher value.
+            """,
+            file: file,
+            line: line
+          )
+          return
+        case .incorrectOrder, .interrupted, .invertedFulfillment:
+          XCTFail("Couldn't snapshot value", file: file, line: line)
+          return
+        @unknown default:
+          XCTFail("Couldn't snapshot value", file: file, line: line)
+          return
+        }
       }
-      guard !isRecording, let expected = expected?()
+      let expected = expected?()
+      guard !isRecording, let expected
       else {
         // NB: Write snapshot state before calling `XCTFail` in case `continueAfterFailure = false`
         inlineSnapshotState[File(path: file), default: []].append(
           InlineSnapshot(
-            expected: expected?(),
+            expected: expected,
             actual: actual,
             wasRecording: isRecording,
             syntaxDescriptor: syntaxDescriptor,
@@ -100,8 +103,8 @@ import Foundation
             Automatically recorded a new snapshot for "\(syntaxDescriptor.trailingClosureLabel)".
             """
         }
-        if let expected = expected?(),
-          let difference = snapshotting.diffing.diff(expected, actual)?.0
+        if let expected,
+          let difference = snapshotting.diffing.diff(expected, actual ?? "")?.0
         {
           failure += " Difference: …\n\n\(difference.indenting(by: 2))"
         }
@@ -116,7 +119,7 @@ import Foundation
         )
         return
       }
-      guard let difference = snapshotting.diffing.diff(expected, actual)?.0
+      guard let difference = snapshotting.diffing.diff(expected, actual ?? "")?.0
       else { return }
 
       let message = message()
@@ -304,7 +307,7 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
 
   private struct InlineSnapshot: Hashable {
     var expected: String?
-    var actual: String
+    var actual: String?
     var wasRecording: Bool
     var syntaxDescriptor: InlineSnapshotSyntaxDescriptor
     var function: String
@@ -421,40 +424,42 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
             .prefix(while: { $0 == " " || $0 == "\t" })
         )
         let delimiter = String(
-          repeating: "#", count: snapshot.actual.hashCount(isMultiline: true)
+          repeating: "#", count: (snapshot.actual ?? "").hashCount(isMultiline: true)
         )
         let leadingIndent = leadingTrivia + self.indent
         let snapshotLabel = TokenSyntax(
           stringLiteral: snapshot.syntaxDescriptor.trailingClosureLabel
         )
-        let snapshotClosure = ClosureExprSyntax(
-          leftBrace: .leftBraceToken(trailingTrivia: .newline),
-          statements: CodeBlockItemListSyntax {
-            StringLiteralExprSyntax(
-              leadingTrivia: Trivia(stringLiteral: leadingIndent),
-              openingPounds: .rawStringPoundDelimiter(delimiter),
-              openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
-              segments: [
-                .stringSegment(
-                  StringSegmentSyntax(
-                    content: .stringSegment(
-                      snapshot.actual
-                        .replacingOccurrences(of: "\r", with: #"\\#(delimiter)r"#)
-                        .indenting(with: leadingIndent)
+        let snapshotClosure = snapshot.actual.map { actual in
+          ClosureExprSyntax(
+            leftBrace: .leftBraceToken(trailingTrivia: .newline),
+            statements: CodeBlockItemListSyntax {
+              StringLiteralExprSyntax(
+                leadingTrivia: Trivia(stringLiteral: leadingIndent),
+                openingPounds: .rawStringPoundDelimiter(delimiter),
+                openingQuote: .multilineStringQuoteToken(trailingTrivia: .newline),
+                segments: [
+                  .stringSegment(
+                    StringSegmentSyntax(
+                      content: .stringSegment(
+                        actual
+                          .replacingOccurrences(of: "\r", with: #"\\#(delimiter)r"#)
+                          .indenting(with: leadingIndent)
+                      )
                     )
                   )
-                )
-              ],
-              closingQuote: .multilineStringQuoteToken(
-                leadingTrivia: .newline + Trivia(stringLiteral: leadingIndent)
-              ),
-              closingPounds: .rawStringPoundDelimiter(delimiter)
+                ],
+                closingQuote: .multilineStringQuoteToken(
+                  leadingTrivia: .newline + Trivia(stringLiteral: leadingIndent)
+                ),
+                closingPounds: .rawStringPoundDelimiter(delimiter)
+              )
+            },
+            rightBrace: .rightBraceToken(
+              leadingTrivia: .newline + Trivia(stringLiteral: leadingTrivia)
             )
-          },
-          rightBrace: .rightBraceToken(
-            leadingTrivia: .newline + Trivia(stringLiteral: leadingTrivia)
           )
-        )
+        }
 
         let arguments = functionCallExpr.arguments
         let firstTrailingClosureOffset =
@@ -475,23 +480,41 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
         switch centeredTrailingClosureOffset {
         case ..<0:
           let index = arguments.index(arguments.startIndex, offsetBy: trailingClosureOffset)
-          functionCallExpr.arguments[index].label = snapshotLabel
-          functionCallExpr.arguments[index].expression = ExprSyntax(snapshotClosure)
+          if let snapshotClosure {
+            functionCallExpr.arguments[index].label = snapshotLabel
+            functionCallExpr.arguments[index].expression = ExprSyntax(snapshotClosure)
+          } else {
+            functionCallExpr.arguments.remove(at: index)
+          }
 
         case 0:
           if snapshot.wasRecording || functionCallExpr.trailingClosure == nil {
             functionCallExpr.rightParen?.trailingTrivia = .space
-            functionCallExpr.trailingClosure = snapshotClosure
+            if let snapshotClosure {
+              functionCallExpr.trailingClosure = snapshotClosure // FIXME: ?? multipleTrailingClosures.removeFirst()
+            } else if !functionCallExpr.additionalTrailingClosures.isEmpty {
+              let additionalTrailingClosure = functionCallExpr.additionalTrailingClosures.remove(
+                at: functionCallExpr.additionalTrailingClosures.startIndex
+              )
+              functionCallExpr.trailingClosure = additionalTrailingClosure.closure
+            } else {
+              functionCallExpr.rightParen?.trailingTrivia = ""
+              functionCallExpr.trailingClosure = nil
+            }
           } else {
             fatalError()
           }
 
         case 1...:
-          var newElement: MultipleTrailingClosureElementSyntax {
-            MultipleTrailingClosureElementSyntax(
-              label: snapshotLabel,
-              closure: snapshotClosure.with(\.leadingTrivia, snapshotClosure.leadingTrivia + .space)
-            )
+          var newElement: MultipleTrailingClosureElementSyntax? {
+            snapshotClosure.map { snapshotClosure in
+              MultipleTrailingClosureElementSyntax(
+                label: snapshotLabel,
+                closure: snapshotClosure.with(
+                  \.leadingTrivia, snapshotClosure.leadingTrivia + .space
+                )
+              )
+            }
           }
 
           if !functionCallExpr.additionalTrailingClosures.isEmpty,
@@ -510,16 +533,20 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
               functionCallExpr.additionalTrailingClosures[index].label.text
             ) {
               if snapshot.wasRecording {
-                functionCallExpr.additionalTrailingClosures[index].label = snapshotLabel
-                functionCallExpr.additionalTrailingClosures[index].closure = snapshotClosure
+                if let snapshotClosure {
+                  functionCallExpr.additionalTrailingClosures[index].label = snapshotLabel
+                  functionCallExpr.additionalTrailingClosures[index].closure = snapshotClosure
+                } else {
+                  functionCallExpr.additionalTrailingClosures.remove(at: index)
+                }
               }
-            } else {
+            } else if let newElement {
               functionCallExpr.additionalTrailingClosures.insert(
                 newElement.with(\.trailingTrivia, .space),
                 at: index
               )
             }
-          } else if centeredTrailingClosureOffset >= 1 {
+          } else if centeredTrailingClosureOffset >= 1, let newElement {
             if let index = functionCallExpr.additionalTrailingClosures.index(
               functionCallExpr.additionalTrailingClosures.endIndex,
               offsetBy: -1,

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -103,9 +103,7 @@ import Foundation
             Automatically recorded a new snapshot for "\(syntaxDescriptor.trailingClosureLabel)".
             """
         }
-        if let expected,
-          let difference = snapshotting.diffing.diff(expected, actual ?? "")?.0
-        {
+        if let difference = snapshotting.diffing.diff(expected ?? "", actual ?? "")?.0 {
           failure += " Difference: …\n\n\(difference.indenting(by: 2))"
         }
         XCTFail(
@@ -540,7 +538,9 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
                   functionCallExpr.additionalTrailingClosures.remove(at: index)
                 }
               }
-            } else if let newElement {
+            } else if let newElement,
+              snapshot.wasRecording || index == functionCallExpr.additionalTrailingClosures.endIndex
+            {
               functionCallExpr.additionalTrailingClosures.insert(
                 newElement.with(\.trailingTrivia, .space),
                 at: index

--- a/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
+++ b/Sources/SnapshotTesting/Snapshotting/URLRequest.swift
@@ -1,128 +1,130 @@
-import Foundation
+#if !os(WASI)
+  import Foundation
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
 
-extension Snapshotting where Value == URLRequest, Format == String {
-  /// A snapshot strategy for comparing requests based on raw equality.
-  ///
-  /// ``` swift
-  /// assertSnapshot(of: request, as: .raw)
-  /// ```
-  ///
-  /// Records:
-  ///
-  /// ```
-  /// POST http://localhost:8080/account
-  /// Cookie: pf_session={"userId":"1"}
-  ///
-  /// email=blob%40pointfree.co&name=Blob
-  /// ```
-  public static let raw = Snapshotting.raw(pretty: false)
+  extension Snapshotting where Value == URLRequest, Format == String {
+    /// A snapshot strategy for comparing requests based on raw equality.
+    ///
+    /// ``` swift
+    /// assertSnapshot(of: request, as: .raw)
+    /// ```
+    ///
+    /// Records:
+    ///
+    /// ```
+    /// POST http://localhost:8080/account
+    /// Cookie: pf_session={"userId":"1"}
+    ///
+    /// email=blob%40pointfree.co&name=Blob
+    /// ```
+    public static let raw = Snapshotting.raw(pretty: false)
 
-  /// A snapshot strategy for comparing requests based on raw equality.
-  ///
-  /// - Parameter pretty: Attempts to pretty print the body of the request (supports JSON).
-  public static func raw(pretty: Bool) -> Snapshotting {
-    return SimplySnapshotting.lines.pullback { (request: URLRequest) in
-      let method =
-        "\(request.httpMethod ?? "GET") \(request.url?.sortingQueryItems()?.absoluteString ?? "(null)")"
+    /// A snapshot strategy for comparing requests based on raw equality.
+    ///
+    /// - Parameter pretty: Attempts to pretty print the body of the request (supports JSON).
+    public static func raw(pretty: Bool) -> Snapshotting {
+      return SimplySnapshotting.lines.pullback { (request: URLRequest) in
+        let method =
+          "\(request.httpMethod ?? "GET") \(request.url?.sortingQueryItems()?.absoluteString ?? "(null)")"
 
-      let headers = (request.allHTTPHeaderFields ?? [:])
-        .map { key, value in "\(key): \(value)" }
-        .sorted()
+        let headers = (request.allHTTPHeaderFields ?? [:])
+          .map { key, value in "\(key): \(value)" }
+          .sorted()
 
-      let body: [String]
-      do {
-        if pretty, #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+        let body: [String]
+        do {
+          if pretty, #available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *) {
+            body =
+              try request.httpBody
+              .map { try JSONSerialization.jsonObject(with: $0, options: []) }
+              .map {
+                try JSONSerialization.data(
+                  withJSONObject: $0, options: [.prettyPrinted, .sortedKeys])
+              }
+              .map { ["\n\(String(decoding: $0, as: UTF8.self))"] }
+              ?? []
+          } else {
+            throw NSError(domain: "co.pointfree.Never", code: 1, userInfo: nil)
+          }
+        } catch {
           body =
-            try request.httpBody
-            .map { try JSONSerialization.jsonObject(with: $0, options: []) }
-            .map {
-              try JSONSerialization.data(
-                withJSONObject: $0, options: [.prettyPrinted, .sortedKeys])
-            }
+            request.httpBody
             .map { ["\n\(String(decoding: $0, as: UTF8.self))"] }
             ?? []
-        } else {
-          throw NSError(domain: "co.pointfree.Never", code: 1, userInfo: nil)
         }
-      } catch {
-        body =
-          request.httpBody
-          .map { ["\n\(String(decoding: $0, as: UTF8.self))"] }
-          ?? []
-      }
 
-      return ([method] + headers + body).joined(separator: "\n")
-    }
-  }
-
-  /// A snapshot strategy for comparing requests based on a cURL representation.
-  ///
-  // ``` swift
-  // assertSnapshot(of: request, as: .curl)
-  // ```
-  //
-  // Records:
-  //
-  // ```
-  // curl \
-  //   --request POST \
-  //   --header "Accept: text/html" \
-  //   --data 'pricing[billing]=monthly&pricing[lane]=individual' \
-  //   "https://www.pointfree.co/subscribe"
-  // ```
-  public static let curl = SimplySnapshotting.lines.pullback { (request: URLRequest) in
-
-    var components = ["curl"]
-
-    // HTTP Method
-    let httpMethod = request.httpMethod!
-    switch httpMethod {
-    case "GET": break
-    case "HEAD": components.append("--head")
-    default: components.append("--request \(httpMethod)")
-    }
-
-    // Headers
-    if let headers = request.allHTTPHeaderFields {
-      for field in headers.keys.sorted() where field != "Cookie" {
-        let escapedValue = headers[field]!.replacingOccurrences(of: "\"", with: "\\\"")
-        components.append("--header \"\(field): \(escapedValue)\"")
+        return ([method] + headers + body).joined(separator: "\n")
       }
     }
 
-    // Body
-    if let httpBodyData = request.httpBody,
-      let httpBody = String(data: httpBodyData, encoding: .utf8)
-    {
-      var escapedBody = httpBody.replacingOccurrences(of: "\\\"", with: "\\\\\"")
-      escapedBody = escapedBody.replacingOccurrences(of: "\"", with: "\\\"")
+    /// A snapshot strategy for comparing requests based on a cURL representation.
+    ///
+    // ``` swift
+    // assertSnapshot(of: request, as: .curl)
+    // ```
+    //
+    // Records:
+    //
+    // ```
+    // curl \
+    //   --request POST \
+    //   --header "Accept: text/html" \
+    //   --data 'pricing[billing]=monthly&pricing[lane]=individual' \
+    //   "https://www.pointfree.co/subscribe"
+    // ```
+    public static let curl = SimplySnapshotting.lines.pullback { (request: URLRequest) in
 
-      components.append("--data \"\(escapedBody)\"")
+      var components = ["curl"]
+
+      // HTTP Method
+      let httpMethod = request.httpMethod!
+      switch httpMethod {
+      case "GET": break
+      case "HEAD": components.append("--head")
+      default: components.append("--request \(httpMethod)")
+      }
+
+      // Headers
+      if let headers = request.allHTTPHeaderFields {
+        for field in headers.keys.sorted() where field != "Cookie" {
+          let escapedValue = headers[field]!.replacingOccurrences(of: "\"", with: "\\\"")
+          components.append("--header \"\(field): \(escapedValue)\"")
+        }
+      }
+
+      // Body
+      if let httpBodyData = request.httpBody,
+        let httpBody = String(data: httpBodyData, encoding: .utf8)
+      {
+        var escapedBody = httpBody.replacingOccurrences(of: "\\\"", with: "\\\\\"")
+        escapedBody = escapedBody.replacingOccurrences(of: "\"", with: "\\\"")
+
+        components.append("--data \"\(escapedBody)\"")
+      }
+
+      // Cookies
+      if let cookie = request.allHTTPHeaderFields?["Cookie"] {
+        let escapedValue = cookie.replacingOccurrences(of: "\"", with: "\\\"")
+        components.append("--cookie \"\(escapedValue)\"")
+      }
+
+      // URL
+      components.append("\"\(request.url!.sortingQueryItems()!.absoluteString)\"")
+
+      return components.joined(separator: " \\\n\t")
     }
+  }
 
-    // Cookies
-    if let cookie = request.allHTTPHeaderFields?["Cookie"] {
-      let escapedValue = cookie.replacingOccurrences(of: "\"", with: "\\\"")
-      components.append("--cookie \"\(escapedValue)\"")
+  extension URL {
+    fileprivate func sortingQueryItems() -> URL? {
+      var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
+      let sortedQueryItems = components?.queryItems?.sorted { $0.name < $1.name }
+      components?.queryItems = sortedQueryItems
+
+      return components?.url
     }
-
-    // URL
-    components.append("\"\(request.url!.sortingQueryItems()!.absoluteString)\"")
-
-    return components.joined(separator: " \\\n\t")
   }
-}
-
-extension URL {
-  fileprivate func sortingQueryItems() -> URL? {
-    var components = URLComponents(url: self, resolvingAgainstBaseURL: false)
-    let sortedQueryItems = components?.queryItems?.sorted { $0.name < $1.name }
-    components?.queryItems = sortedQueryItems
-
-    return components?.url
-  }
-}
+#endif


### PR DESCRIPTION
This updates `assertInlineSnapshot` to match against an optional, so that when `nil` is provided, the snapshot helper can scrub the trailing snapshot closure.

This can be used by downstream helpers, like `assertMacro` to "un-record" certain snapshots when it makes sense to: _e.g._ when removing an `expansion` and recording a new `diagnostic` instead.