### PR TITLE
Add link to plugin SnapshotVision.

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,9 @@ targets: [
   - [SnapshotTestingHEIC](https://github.com/alexey1312/SnapshotTestingHEIC) adds image support
   using the HEIC storage format which reduces file sizes in comparison to PNG.
 
+  - [SnapshotVision](https://github.com/gregersson/swift-snapshot-testing-vision) adds snapshot
+    strategy for text recognition on views and images. Uses Apples Vision framework.
+
 Have you written your own SnapshotTesting plug-in?
 [Add it here](https://github.com/pointfreeco/swift-snapshot-testing/edit/master/README.md) and
 submit a pull request!


### PR DESCRIPTION
A tiny plugin that wraps Apples Vision framework. It allows for snapshotting views based on what texts can be seen. It currently only supports iOS. 