### PR TITLE
Store paths of accessed snapshot files

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -8,6 +8,8 @@ import XCTest
 /// ```
 public var diffTool: String? = nil
 
+public var accessedFilePaths: Set<URL> = []
+
 /// Whether or not to record all new references.
 public var isRecording = false
 
@@ -226,6 +228,8 @@ public func verifySnapshot<Value, Format>(
       .appendingPathExtension(snapshotting.pathExtension ?? "")
     let fileManager = FileManager.default
     try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)
+      
+    accessedFilePaths.insert(snapshotFileUrl)
 
     let tookSnapshot = XCTestExpectation(description: "Took snapshot")
     var optionalDiffable: Format?


### PR DESCRIPTION
This PR adds a property which keeps track of all snapshot file-paths accessed when running snapshot tests.

This is useful in order to check whether any unused snapshot files have been unintentionally added to/left in your project.