### PR TITLE
Make ViewImageConfig Sendable

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -12,7 +12,7 @@
   #endif
 
   #if os(iOS) || os(tvOS)
-    public struct ViewImageConfig {
+    public struct ViewImageConfig: Sendable {
       public enum Orientation {
         case landscape
         case portrait


### PR DESCRIPTION
I got the following warning when I added strict concurrency checking to my project.
<img width="1302" alt="Snímek obrazovky 2024-04-28 v 14 10 57" src="https://github.com/pointfreeco/swift-snapshot-testing/assets/15653162/9c8063c4-69c8-47ab-ac6b-2b1182c7bf81">
So I decided to suppress them by conforming `ViewImageConfig` to `Sendable` protocol. I hope it's ok to do that.