### PR TITLE
fix snapshots for wkwebview to let data load

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -869,9 +869,6 @@
                     return
                   }
                   let configuration = WKSnapshotConfiguration()
-                  if #available(iOS 13, macOS 10.15, *) {
-                    configuration.afterScreenUpdates = false
-                  }
                   wkWebView.takeSnapshot(with: configuration) { image, _ in
                     callback(image!)
                   }


### PR DESCRIPTION
## In this PR
Since ver1.15.2, snapshots have been broken for WKWebView since it no more lets the data load before taking snapshot. This has broken our(private company) tests since we want to verify that the data we pass wkwebview loadsl before taking a snapshot. As a result, we've been forced to stick to 1.15.0.
This PR reverts that change from 1.15.2. Happy to have a conversation regarding this particular fix which was done for a different issue.