### PR TITLE
Configure `isRecording` default value with launch argument

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -9,7 +9,16 @@ import XCTest
 public var diffTool: String? = nil
 
 /// Whether or not to record all new references.
-public var isRecording = false
+public var isRecording: Bool = {
+  let args = ProcessInfo.processInfo.arguments
+  if let index = args.firstIndex(of: "-co.pointfree.SnapshotTesting.IsRecording"),
+      index < args.count - 1,
+      args[index + 1] == "1"
+  {
+    return true
+  }
+  return false
+}()
 
 /// Whether or not to record all new references.
 ///


### PR DESCRIPTION
We often want to reset all the snapshots during development of foundational/utility domains that may invalidate many snapshots in many files, and it is currently inconvenient to search and flip flags for these tests.

This PR exposes a launch argument that allows to seed the default of `isRecording` by passing `-co.pointfree.SnapshotTesting.IsRecording 1`. It is very convenient to have a dedicated scheme (or to use the checkbox) to regenerate all snapshots in a project. This only sets the default value, so it shouldn't affect local `isRecording` overrides.

The naming is inspired from the various arguments Apple provides for CoreData, like `-com.apple.CoreData.SQLDebug 1` ([See here](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/CoreData/TroubleshootingCoreData.html#//apple_ref/doc/uid/TP40001075-CH26-SW1), "Debugging Fetching"). It can of course be discussed.

This is fairly additional. Some users have reported more or less involved workarounds (like using subclasses of XCTestCase, or CI scripts), but this solution would make this problem much easier to solve IMO.