### PR TITLE
Fix recordIssue for Xcode beta 3.

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -39,7 +39,7 @@ import Foundation
     timeout: TimeInterval = 5,
     syntaxDescriptor: InlineSnapshotSyntaxDescriptor = InlineSnapshotSyntaxDescriptor(),
     matches expected: (() -> String)? = nil,
-    file: StaticString = #filePath,
+    file: StaticString = #file,
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
@@ -77,10 +77,22 @@ import Foundation
             )
             return
           case .incorrectOrder, .interrupted, .invertedFulfillment:
-            recordIssue("Couldn't snapshot value", file: file, line: line)
+            recordIssue(
+              "Couldn't snapshot value",
+              fileID: file,
+              filePath: file,
+              line: line,
+              column: 0
+            )
             return
           @unknown default:
-            recordIssue("Couldn't snapshot value", file: file, line: line)
+            recordIssue(
+              "Couldn't snapshot value",
+              fileID: file,
+              filePath: file,
+              line: line,
+              column: 0
+            )
             return
           }
         }
@@ -121,8 +133,10 @@ import Foundation
 
             Re-run "\(function)" to assert against the newly-recorded snapshot.
             """,
-            file: file,
-            line: line
+            fileID: file,
+            filePath: file,
+            line: line,
+            column: 0
           )
           return
         }
@@ -133,8 +147,10 @@ import Foundation
             """
             No expected value to assert against.
             """,
-            file: file,
-            line: line
+            fileID: file,
+            filePath: file,
+            line: line,
+            column: 0
           )
           return
         }
@@ -154,7 +170,13 @@ import Foundation
           column: column
         )
       } catch {
-        recordIssue("Threw error: \(error)", file: file, line: line)
+        recordIssue(
+          "Threw error: \(error)",
+          fileID: file,
+          filePath: file,
+          line: line,
+          column: 0
+        )
       }
     }
   }

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -70,8 +70,10 @@ import Foundation
               loaded. If a timeout is unavoidable, consider setting the "timeout" parameter of
               "assertInlineSnapshot" to a higher value.
               """,
-              file: file,
-              line: line
+              fileID: file,
+              filePath: file,
+              line: line,
+              column: 0
             )
             return
           case .incorrectOrder, .interrupted, .invertedFulfillment:
@@ -267,8 +269,11 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       }
       recordIssue(
         message(),
-        file: file,
-        line: trailingClosureLine.map(UInt.init) ?? line
+        fileID: file,
+        filePath: file,
+        line: trailingClosureLine.map(UInt.init) ?? line,
+        column: 0
+
       )
     }
 

--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -23,14 +23,16 @@ import Foundation
   ///   - expected: An optional closure that returns a previously generated snapshot. When omitted,
   ///     the library will automatically write a snapshot into your test file at the call sight of
   ///     the assertion.
-  ///   - file: The file where the assertion occurs. The default is the filename of the test case
-  ///     where you call this function.
+  ///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
+  ///     which this function was called.
+  ///   - file: The file in which failure occurred. Defaults to the file path of the test case in
+  ///     which this function was called.
   ///   - function: The function where the assertion occurs. The default is the name of the test
   ///     method where you call this function.
-  ///   - line: The line where the assertion occurs. The default is the line number where you call
-  ///     this function.
-  ///   - column: The column where the assertion occurs. The default is the line column you call
-  ///     this function.
+  ///   - line: The line number on which failure occurred. Defaults to the line number on which this
+  ///     function was called.
+  ///   - column: The column on which failure occurred. Defaults to the column on which this
+  ///     function was called.
   public func assertInlineSnapshot<Value>(
     of value: @autoclosure () throws -> Value?,
     as snapshotting: Snapshotting<Value, String>,
@@ -39,7 +41,8 @@ import Foundation
     timeout: TimeInterval = 5,
     syntaxDescriptor: InlineSnapshotSyntaxDescriptor = InlineSnapshotSyntaxDescriptor(),
     matches expected: (() -> String)? = nil,
-    file: StaticString = #file,
+    fileID: StaticString = #fileID,
+    file filePath: StaticString = #filePath,
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
@@ -70,28 +73,28 @@ import Foundation
               loaded. If a timeout is unavoidable, consider setting the "timeout" parameter of
               "assertInlineSnapshot" to a higher value.
               """,
-              fileID: file,
-              filePath: file,
+              fileID: fileID,
+              filePath: filePath,
               line: line,
-              column: 0
+              column: column
             )
             return
           case .incorrectOrder, .interrupted, .invertedFulfillment:
             recordIssue(
               "Couldn't snapshot value",
-              fileID: file,
-              filePath: file,
+              fileID: fileID,
+              filePath: filePath,
               line: line,
-              column: 0
+              column: column
             )
             return
           @unknown default:
             recordIssue(
               "Couldn't snapshot value",
-              fileID: file,
-              filePath: file,
+              fileID: fileID,
+              filePath: filePath,
               line: line,
-              column: 0
+              column: column
             )
             return
           }
@@ -102,7 +105,7 @@ import Foundation
           record != .missing || expected != nil
         else {
           // NB: Write snapshot state before calling `XCTFail` in case `continueAfterFailure = false`
-          inlineSnapshotState[File(path: file), default: []].append(
+          inlineSnapshotState[File(path: filePath), default: []].append(
             InlineSnapshot(
               expected: expected,
               actual: actual,
@@ -133,10 +136,10 @@ import Foundation
 
             Re-run "\(function)" to assert against the newly-recorded snapshot.
             """,
-            fileID: file,
-            filePath: file,
+            fileID: fileID,
+            filePath: filePath,
             line: line,
-            column: 0
+            column: column
           )
           return
         }
@@ -147,10 +150,10 @@ import Foundation
             """
             No expected value to assert against.
             """,
-            fileID: file,
-            filePath: file,
+            fileID: fileID,
+            filePath: filePath,
             line: line,
-            column: 0
+            column: column
           )
           return
         }
@@ -165,17 +168,18 @@ import Foundation
 
           \(difference.indenting(by: 2))
           """,
-          file: file,
+          fileID: fileID,
+          file: filePath,
           line: line,
           column: column
         )
       } catch {
         recordIssue(
           "Threw error: \(error)",
-          fileID: file,
-          filePath: file,
+          fileID: fileID,
+          filePath: filePath,
           line: line,
-          column: 0
+          column: column
         )
       }
     }
@@ -183,13 +187,15 @@ import Foundation
 #else
   @available(*, unavailable, message: "'assertInlineSnapshot' requires 'swift-syntax' >= 509.0.0")
   public func assertInlineSnapshot<Value>(
-    of value: @autoclosure () throws -> Value,
+    of value: @autoclosure () throws -> Value?,
     as snapshotting: Snapshotting<Value, String>,
     message: @autoclosure () -> String = "",
+    record isRecording: Bool? = nil,
     timeout: TimeInterval = 5,
     syntaxDescriptor: InlineSnapshotSyntaxDescriptor = InlineSnapshotSyntaxDescriptor(),
     matches expected: (() -> String)? = nil,
-    file: StaticString = #filePath,
+    fileID: StaticString = #fileID,
+    file filePath: StaticString = #filePath,
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
@@ -266,20 +272,23 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
     ///
     /// - Parameters:
     ///   - message: An optional description of the assertion, for inclusion in test results.
-    ///   - file: The file where the assertion occurs. The default is the filename of the test case
-    ///     where you call `assertInlineSnapshot`.
-    ///   - line: The line where the assertion occurs. The default is the line number where you call
-    ///     `assertInlineSnapshot`.
-    ///   - column: The column where the assertion occurs. The default is the column where you call
-    ///     `assertInlineSnapshot`.
+    ///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case
+    ///     in which this function was called.
+    ///   - file: The file in which failure occurred. Defaults to the file path of the test case in
+    ///     which this function was called.
+    ///   - line: The line number on which failure occurred. Defaults to the line number on which
+    ///     this function was called.
+    ///   - column: The column on which failure occurred. Defaults to the column on which this
+    ///     function was called.
     public func fail(
       _ message: @autoclosure () -> String = "",
-      file: StaticString,
+      fileID: StaticString,
+      file filePath: StaticString,
       line: UInt,
       column: UInt
     ) {
       var trailingClosureLine: Int?
-      if let testSource = try? testSource(file: File(path: file)) {
+      if let testSource = try? testSource(file: File(path: filePath)) {
         let visitor = SnapshotVisitor(
           functionCallLine: Int(line),
           functionCallColumn: Int(column),
@@ -291,11 +300,10 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
       }
       recordIssue(
         message(),
-        fileID: file,
-        filePath: file,
+        fileID: fileID,
+        filePath: filePath,
         line: trailingClosureLine.map(UInt.init) ?? line,
-        column: 0
-
+        column: column
       )
     }
 
@@ -306,7 +314,8 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
     @available(*, unavailable, message: "'assertInlineSnapshot' requires 'swift-syntax' >= 509.0.0")
     public func fail(
       _ message: @autoclosure () -> String = "",
-      file: StaticString,
+      fileID: StaticString,
+      file filePath: StaticString,
       line: UInt,
       column: UInt
     ) {

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -45,21 +45,27 @@ public var _record: SnapshotTestingConfiguration.Record = {
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
 ///   - timeout: The amount of time a snapshot must be generated in.
-///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
+///     which this function was called.
+///   - file: The file in which failure occurred. Defaults to the file path of the test case in
 ///     which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of
 ///     the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this
 ///     function was called.
+///   - column: The column on which failure occurred. Defaults to the column on which this function
+///     was called.
 public func assertSnapshot<Value, Format>(
   of value: @autoclosure () throws -> Value,
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool? = nil,
   timeout: TimeInterval = 5,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   let failure = verifySnapshot(
     of: try value(),
@@ -67,12 +73,20 @@ public func assertSnapshot<Value, Format>(
     named: name,
     record: recording,
     timeout: timeout,
-    file: file,
+    fileID: fileID,
+    file: filePath,
     testName: testName,
-    line: line
+    line: line,
+    column: column
   )
   guard let message = failure else { return }
-  recordIssue(message, fileID: file, filePath: file, line: line, column: 0)
+  recordIssue(
+    message,
+    fileID: fileID,
+    filePath: filePath,
+    line: line,
+    column: column
+  )
 }
 
 /// Asserts that a given value matches references on disk.
@@ -83,20 +97,26 @@ public func assertSnapshot<Value, Format>(
 ///     comparing values.
 ///   - recording: Whether or not to record a new reference.
 ///   - timeout: The amount of time a snapshot must be generated in.
-///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
+///     which this function was called.
+///   - file: The file in which failure occurred. Defaults to the file path of the test case in
 ///     which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of
 ///     the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this
 ///     function was called.
+///   - column: The column on which failure occurred. Defaults to the column on which this function
+///     was called.
 public func assertSnapshots<Value, Format>(
   of value: @autoclosure () throws -> Value,
   as strategies: [String: Snapshotting<Value, Format>],
   record recording: Bool? = nil,
   timeout: TimeInterval = 5,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   try? strategies.forEach { name, strategy in
     assertSnapshot(
@@ -105,9 +125,11 @@ public func assertSnapshots<Value, Format>(
       named: name,
       record: recording,
       timeout: timeout,
-      file: file,
+      fileID: fileID,
+      file: filePath,
       testName: testName,
-      line: line
+      line: line,
+      column: column
     )
   }
 }
@@ -119,20 +141,26 @@ public func assertSnapshots<Value, Format>(
 ///   - strategies: An array of strategies for serializing, deserializing, and comparing values.
 ///   - recording: Whether or not to record a new reference.
 ///   - timeout: The amount of time a snapshot must be generated in.
-///   - file: The file in which failure occurred. Defaults to the file name of the test case in
+///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
+///     which this function was called.
+///   - file: The file in which failure occurred. Defaults to the file path of the test case in
 ///     which this function was called.
 ///   - testName: The name of the test in which failure occurred. Defaults to the function name of
 ///     the test case in which this function was called.
 ///   - line: The line number on which failure occurred. Defaults to the line number on which this
 ///     function was called.
+///   - column: The column on which failure occurred. Defaults to the column on which this function
+///     was called.
 public func assertSnapshots<Value, Format>(
   of value: @autoclosure () throws -> Value,
   as strategies: [Snapshotting<Value, Format>],
   record recording: Bool? = nil,
   timeout: TimeInterval = 5,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   try? strategies.forEach { strategy in
     assertSnapshot(
@@ -140,9 +168,11 @@ public func assertSnapshots<Value, Format>(
       as: strategy,
       record: recording,
       timeout: timeout,
-      file: file,
+      fileID: fileID,
+      file: filePath,
       testName: testName,
-      line: line
+      line: line,
+      column: column
     )
   }
 }
@@ -205,9 +235,11 @@ public func verifySnapshot<Value, Format>(
   record recording: Bool? = nil,
   snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #file,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) -> String? {
   CleanCounterBetweenTestCases.registerIfNeeded()
 
@@ -217,7 +249,7 @@ public func verifySnapshot<Value, Format>(
     ?? _record
   return withSnapshotTesting(record: record) { () -> String? in
     do {
-      let fileUrl = URL(fileURLWithPath: "\(file)", isDirectory: false)
+      let fileUrl = URL(fileURLWithPath: "\(filePath)", isDirectory: false)
       let fileName = fileUrl.deletingPathExtension().lastPathComponent
 
       let snapshotDirectoryUrl =

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -72,7 +72,7 @@ public func assertSnapshot<Value, Format>(
     line: line
   )
   guard let message = failure else { return }
-  recordIssue(message, file: file, line: line)
+  recordIssue(message, fileID: file, filePath: file, line: line, column: 0)
 }
 
 /// Asserts that a given value matches references on disk.

--- a/Sources/SnapshotTesting/Internal/Deprecations.swift
+++ b/Sources/SnapshotTesting/Internal/Deprecations.swift
@@ -14,9 +14,11 @@ public func _assertInlineSnapshot<Value>(
   record recording: Bool = false,
   timeout: TimeInterval = 5,
   with reference: String,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 ) {
 
   let failure = _verifyInlineSnapshot(
@@ -25,12 +27,14 @@ public func _assertInlineSnapshot<Value>(
     record: recording,
     timeout: timeout,
     with: reference,
-    file: file,
+    fileID: fileID,
+    file: filePath,
     testName: testName,
-    line: line
+    line: line,
+    column: column
   )
   guard let message = failure else { return }
-  recordIssue(message, fileID: file, filePath: file, line: line, column: 0)
+  recordIssue(message, fileID: fileID, filePath: filePath, line: line, column: column)
 }
 
 @available(
@@ -44,9 +48,11 @@ public func _verifyInlineSnapshot<Value>(
   record recording: Bool = false,
   timeout: TimeInterval = 5,
   with reference: String,
-  file: StaticString = #file,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   testName: String = #function,
-  line: UInt = #line
+  line: UInt = #line,
+  column: UInt = #column
 )
   -> String?
 {
@@ -94,7 +100,7 @@ public func _verifyInlineSnapshot<Value>(
 
     // If that diff failed, we either record or fail.
     if recording || trimmedReference.isEmpty {
-      let fileName = "\(file)"
+      let fileName = "\(filePath)"
       let sourceCodeFilePath = URL(fileURLWithPath: fileName, isDirectory: false)
       let sourceCode = try String(contentsOf: sourceCodeFilePath)
       var newRecordings = recordings

--- a/Sources/SnapshotTesting/Internal/Deprecations.swift
+++ b/Sources/SnapshotTesting/Internal/Deprecations.swift
@@ -30,7 +30,7 @@ public func _assertInlineSnapshot<Value>(
     line: line
   )
   guard let message = failure else { return }
-  recordIssue(message, file: file, line: line)
+  recordIssue(message, fileID: file, filePath: file, line: line, column: 0)
 }
 
 @available(

--- a/Sources/SnapshotTesting/Internal/RecordIssue.swift
+++ b/Sources/SnapshotTesting/Internal/RecordIssue.swift
@@ -27,6 +27,6 @@ public func recordIssue(
       XCTFail(message(), file: filePath, line: line)
     }
   #else
-    XCTFail(message(), file: file, line: line)
+    XCTFail(message(), file: filePath, line: line)
   #endif
 }

--- a/Sources/SnapshotTesting/Internal/RecordIssue.swift
+++ b/Sources/SnapshotTesting/Internal/RecordIssue.swift
@@ -7,10 +7,10 @@ import XCTest
 @_spi(Internals)
 public func recordIssue(
   _ message: @autoclosure () -> String,
-  fileID: StaticString = #fileID,
-  filePath: StaticString = #filePath,
-  line: UInt = #line,
-  column: UInt = #column
+  fileID: StaticString,
+  filePath: StaticString,
+  line: UInt,
+  column: UInt
 ) {
   #if canImport(Testing)
     if Test.current != nil {

--- a/Sources/SnapshotTesting/Internal/RecordIssue.swift
+++ b/Sources/SnapshotTesting/Internal/RecordIssue.swift
@@ -7,18 +7,24 @@ import XCTest
 @_spi(Internals)
 public func recordIssue(
   _ message: @autoclosure () -> String,
-  file: StaticString = #filePath,
-  line: UInt = #line
+  fileID: StaticString = #fileID,
+  filePath: StaticString = #filePath,
+  line: UInt = #line,
+  column: UInt = #column
 ) {
   #if canImport(Testing)
     if Test.current != nil {
       Issue.record(
         Comment(rawValue: message()),
-        filePath: file.description,
-        line: Int(line)
+        sourceLocation: SourceLocation(
+          fileID: fileID.description,
+          filePath: filePath.description,
+          line: Int(line),
+          column: Int(column)
+        )
       )
     } else {
-      XCTFail(message(), file: file, line: line)
+      XCTFail(message(), file: filePath, line: line)
     }
   #else
     XCTFail(message(), file: file, line: line)

--- a/Tests/InlineSnapshotTestingTests/AssertInlineSnapshotSwiftTests.swift
+++ b/Tests/InlineSnapshotTestingTests/AssertInlineSnapshotSwiftTests.swift
@@ -102,7 +102,8 @@
     @Test func argumentlessInlineSnapshot() {
       func assertArgumentlessInlineSnapshot(
         expected: (() -> String)? = nil,
-        file: StaticString = #filePath,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
         function: StaticString = #function,
         line: UInt = #line,
         column: UInt = #column
@@ -115,7 +116,8 @@
             trailingClosureOffset: 1
           ),
           matches: expected,
-          file: file,
+          fileID: fileID,
+          file: filePath,
           function: function,
           line: line,
           column: column
@@ -135,7 +137,8 @@
         of url: () -> String,
         head: (() -> String)? = nil,
         body: (() -> String)? = nil,
-        file: StaticString = #filePath,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
         function: StaticString = #function,
         line: UInt = #line,
         column: UInt = #column
@@ -152,7 +155,8 @@
             trailingClosureOffset: 1
           ),
           matches: head,
-          file: file,
+          fileID: fileID,
+          file: filePath,
           function: function,
           line: line,
           column: column
@@ -178,7 +182,8 @@
             trailingClosureOffset: 2
           ),
           matches: body,
-          file: file,
+          fileID: fileID,
+          file: filePath,
           function: function,
           line: line,
           column: column
@@ -215,7 +220,8 @@
       func assertAsyncThrowingInlineSnapshot(
         of value: () -> String,
         is expected: (() -> String)? = nil,
-        file: StaticString = #filePath,
+        fileID: StaticString = #fileID,
+        filePath: StaticString = #filePath,
         function: StaticString = #function,
         line: UInt = #line,
         column: UInt = #column
@@ -228,7 +234,8 @@
             trailingClosureOffset: 1
           ),
           matches: expected,
-          file: file,
+          fileID: fileID,
+          file: filePath,
           function: function,
           line: line,
           column: column
@@ -284,7 +291,8 @@
   private func assertCustomInlineSnapshot(
     of value: () -> String,
     is expected: (() -> String)? = nil,
-    file: StaticString = #filePath,
+    fileID: StaticString = #fileID,
+    filePath: StaticString = #filePath,
     function: StaticString = #function,
     line: UInt = #line,
     column: UInt = #column
@@ -297,7 +305,8 @@
         trailingClosureOffset: 1
       ),
       matches: expected,
-      file: file,
+      fileID: fileID,
+      file: filePath,
       function: function,
       line: line,
       column: column

--- a/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
+++ b/Tests/InlineSnapshotTestingTests/InlineSnapshotTestingTests.swift
@@ -102,7 +102,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
   func testArgumentlessInlineSnapshot() {
     func assertArgumentlessInlineSnapshot(
       expected: (() -> String)? = nil,
-      file: StaticString = #filePath,
+      fileID: StaticString = #fileID,
+      file filePath: StaticString = #filePath,
       function: StaticString = #function,
       line: UInt = #line,
       column: UInt = #column
@@ -115,7 +116,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
           trailingClosureOffset: 1
         ),
         matches: expected,
-        file: file,
+        fileID: fileID,
+        file: filePath,
         function: function,
         line: line,
         column: column
@@ -135,7 +137,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
       of url: () -> String,
       head: (() -> String)? = nil,
       body: (() -> String)? = nil,
-      file: StaticString = #filePath,
+      fileID: StaticString = #fileID,
+      file filePath: StaticString = #filePath,
       function: StaticString = #function,
       line: UInt = #line,
       column: UInt = #column
@@ -152,7 +155,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
           trailingClosureOffset: 1
         ),
         matches: head,
-        file: file,
+        fileID: fileID,
+        file: filePath,
         function: function,
         line: line,
         column: column
@@ -178,7 +182,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
           trailingClosureOffset: 2
         ),
         matches: body,
-        file: file,
+        fileID: fileID,
+        file: filePath,
         function: function,
         line: line,
         column: column
@@ -215,7 +220,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
     func assertAsyncThrowingInlineSnapshot(
       of value: () -> String,
       is expected: (() -> String)? = nil,
-      file: StaticString = #filePath,
+      fileID: StaticString = #fileID,
+      file filePath: StaticString = #filePath,
       function: StaticString = #function,
       line: UInt = #line,
       column: UInt = #column
@@ -228,7 +234,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
           trailingClosureOffset: 1
         ),
         matches: expected,
-        file: file,
+        fileID: fileID,
+        file: filePath,
         function: function,
         line: line,
         column: column
@@ -284,7 +291,8 @@ final class InlineSnapshotTestingTests: XCTestCase {
 private func assertCustomInlineSnapshot(
   of value: () -> String,
   is expected: (() -> String)? = nil,
-  file: StaticString = #filePath,
+  fileID: StaticString = #fileID,
+  file filePath: StaticString = #filePath,
   function: StaticString = #function,
   line: UInt = #line,
   column: UInt = #column
@@ -297,7 +305,8 @@ private func assertCustomInlineSnapshot(
       trailingClosureOffset: 1
     ),
     matches: expected,
-    file: file,
+    fileID: fileID,
+    file: filePath,
     function: function,
     line: line,
     column: column


### PR DESCRIPTION
Fixes #868 

Xcode beta 3 changed the signature of `Issue.record` to take a source location instead of individual file/line/column. 