### PR TITLE
Don't invoke XCTContext when running in the Testing framework.

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -311,7 +311,10 @@ public func verifySnapshot<Value, Format>(
       func recordSnapshot() throws {
         try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
         #if !os(Linux) && !os(Windows)
-          if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
+          if
+            !isSwiftTesting,
+            ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS")
+        {
             XCTContext.runActivity(named: "Attached Recorded Snapshot") { activity in
               let attachment = XCTAttachment(contentsOfFile: snapshotFileUrl)
               activity.add(attachment)

--- a/Sources/SnapshotTesting/Internal/RecordIssue.swift
+++ b/Sources/SnapshotTesting/Internal/RecordIssue.swift
@@ -4,6 +4,14 @@ import XCTest
   import Testing
 #endif
 
+var isSwiftTesting: Bool {
+#if canImport(Testing)
+  return Test.current != nil
+  #else
+  return false
+  #endif
+}
+
 @_spi(Internals)
 public func recordIssue(
   _ message: @autoclosure () -> String,

--- a/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
+++ b/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
@@ -1,0 +1,19 @@
+#if canImport(Testing)
+  import Testing
+  import Foundation
+  import InlineSnapshotTesting
+  @_spi(Experimental) import SnapshotTesting
+
+  @Suite(
+    .snapshots(
+      record: .missing
+    )
+  )
+  struct AssertSnapshotTests {
+    @Test func dump() {
+      struct User { let id: Int, name: String, bio: String }
+      let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
+      assertSnapshot(of: user, as: .dump)
+    }
+  }
+#endif

--- a/Tests/SnapshotTestingTests/__Snapshots__/AssertSnapshotSwiftTests/dump.1.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/AssertSnapshotSwiftTests/dump.1.txt
@@ -1,0 +1,4 @@
+▿ User
+  - bio: "Blobbed around the world."
+  - id: 1
+  - name: "Blobby"


### PR DESCRIPTION
Fixes #883 