### PR TITLE
Xcode 16 beta 5: Fix snapshots test trait

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -1,5 +1,9 @@
 import XCTest
 
+#if canImport(Testing)
+  import Testing
+#endif
+
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted
 /// into a terminal.
 @available(
@@ -9,12 +13,33 @@ import XCTest
     "Use 'withSnapshotTesting' to customize the diff tool. See the documentation for more information."
 )
 public var diffTool: SnapshotTestingConfiguration.DiffTool {
-  get { _diffTool }
+  get {
+    _diffTool
+  }
   set { _diffTool = newValue }
 }
 
 @_spi(Internals)
-public var _diffTool: SnapshotTestingConfiguration.DiffTool = .default
+public var _diffTool: SnapshotTestingConfiguration.DiffTool {
+  get {
+    #if canImport(Testing)
+      if let test = Test.current {
+        for trait in test.traits.reversed() {
+          if let diffTool = (trait as? _SnapshotsTestTrait)?.configuration.diffTool {
+            return diffTool
+          }
+        }
+      }
+    #endif
+    return __diffTool
+  }
+  set {
+    __diffTool = newValue
+  }
+}
+
+@_spi(Internals)
+public var __diffTool: SnapshotTestingConfiguration.DiffTool = .default
 
 /// Whether or not to record all new references.
 @available(
@@ -28,7 +53,26 @@ public var isRecording: Bool {
 }
 
 @_spi(Internals)
-public var _record: SnapshotTestingConfiguration.Record = {
+public var _record: SnapshotTestingConfiguration.Record {
+  get {
+    #if canImport(Testing)
+      if let test = Test.current {
+        for trait in test.traits.reversed() {
+          if let record = (trait as? _SnapshotsTestTrait)?.configuration.record {
+            return record
+          }
+        }
+      }
+    #endif
+    return __record
+  }
+  set {
+    __record = newValue
+  }
+}
+
+@_spi(Internals)
+public var __record: SnapshotTestingConfiguration.Record = {
   if let value = ProcessInfo.processInfo.environment["SNAPSHOT_TESTING_RECORD"],
     let record = SnapshotTestingConfiguration.Record(rawValue: value)
   {

--- a/Sources/SnapshotTesting/SnapshotsTestTrait.swift
+++ b/Sources/SnapshotTesting/SnapshotsTestTrait.swift
@@ -1,5 +1,5 @@
 #if canImport(Testing)
-  @_spi(Experimental) import Testing
+  import Testing
 
   @_spi(Experimental)
   extension Trait where Self == _SnapshotsTestTrait {
@@ -32,21 +32,21 @@
 
   /// A type representing the configuration of snapshot testing.
   @_spi(Experimental)
-  public struct _SnapshotsTestTrait: CustomExecutionTrait, SuiteTrait, TestTrait {
+  public struct _SnapshotsTestTrait: SuiteTrait, TestTrait {
     public let isRecursive = true
     let configuration: SnapshotTestingConfiguration
 
-    public func execute(
-      _ function: @escaping () async throws -> Void,
-      for test: Test,
-      testCase: Test.Case?
-    ) async throws {
-      try await withSnapshotTesting(
-        record: configuration.record,
-        diffTool: configuration.diffTool
-      ) {
-        try await function()
-      }
-    }
+    // public func execute(
+    //   _ function: @escaping () async throws -> Void,
+    //   for test: Test,
+    //   testCase: Test.Case?
+    // ) async throws {
+    //   try await withSnapshotTesting(
+    //     record: configuration.record,
+    //     diffTool: configuration.diffTool
+    //   ) {
+    //     try await function()
+    //   }
+    // }
   }
 #endif

--- a/Tests/SnapshotTestingTests/SnapshotsTraitTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotsTraitTests.swift
@@ -1,13 +1,12 @@
 #if compiler(>=6) && canImport(Testing)
-  @_spi(Experimental) import Testing
+import Testing
   @_spi(Experimental) @_spi(Internals) import SnapshotTesting
 
   struct SnapshotsTraitTests {
     @Test(.snapshots(diffTool: "ksdiff"))
     func testDiffTool() {
       #expect(
-        SnapshotTestingConfiguration.current?
-          .diffTool?(currentFilePath: "old.png", failedFilePath: "new.png")
+        _diffTool(currentFilePath: "old.png", failedFilePath: "new.png")
           == "ksdiff old.png new.png"
       )
     }
@@ -17,8 +16,7 @@
       @Test(.snapshots(diffTool: "difftool"))
       func testDiffToolOverride() {
         #expect(
-          SnapshotTestingConfiguration.current?
-            .diffTool?(currentFilePath: "old.png", failedFilePath: "new.png")
+          _diffTool(currentFilePath: "old.png", failedFilePath: "new.png")
             == "difftool old.png new.png"
         )
       }
@@ -28,11 +26,10 @@
         @Test
         func config() {
           #expect(
-            SnapshotTestingConfiguration.current?
-              .diffTool?(currentFilePath: "old.png", failedFilePath: "new.png")
+            _diffTool(currentFilePath: "old.png", failedFilePath: "new.png")
               == "ksdiff old.png new.png"
           )
-          #expect(SnapshotTestingConfiguration.current?.record == .all)
+          #expect(_record == .all)
         }
 
         @Suite(.snapshots(record: .failed, diffTool: "diff"))
@@ -40,11 +37,10 @@
           @Test
           func config() {
             #expect(
-              SnapshotTestingConfiguration.current?
-                .diffTool?(currentFilePath: "old.png", failedFilePath: "new.png")
+              _diffTool(currentFilePath: "old.png", failedFilePath: "new.png")
                 == "diff old.png new.png"
             )
-            #expect(SnapshotTestingConfiguration.current?.record == .failed)
+            #expect(_record == .failed)
           }
         }
       }


### PR DESCRIPTION
It is no longer possible to `@_spi(Experimental) import Testing`, so we can no longer ship a custom execution test trait.

Instead of using such a trait to override a task local for the duration of a test, we can use a more general trait to store the information, and the assertion helpers can coalesce to the trait, instead.