### PR TITLE
Feature/fixed decimal separator

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -153,6 +153,7 @@
 
   private let defaultNumberFormatter: NumberFormatter = {
     let numberFormatter = NumberFormatter()
+    numberFormatter.decimalSeparator = "."
     numberFormatter.minimumFractionDigits = 1
     numberFormatter.maximumFractionDigits = 3
     return numberFormatter

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -105,6 +105,7 @@
 
   private let defaultNumberFormatter: NumberFormatter = {
     let numberFormatter = NumberFormatter()
+    numberFormatter.decimalSeparator = "."
     numberFormatter.minimumFractionDigits = 1
     numberFormatter.maximumFractionDigits = 3
     return numberFormatter

--- a/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
+++ b/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
@@ -1,7 +1,6 @@
 #if canImport(Testing)
   import Testing
   import Foundation
-  import InlineSnapshotTesting
   @_spi(Experimental) import SnapshotTesting
 
   @Suite(


### PR DESCRIPTION
I saw this in https://github.com/pointfreeco/swift-snapshot-testing/pull/533 and as I'm in Belgium where we use , as a decimal separator I also noticed my snapshots changed.

As It is unclear if https://github.com/pointfreeco/swift-snapshot-testing/pull/533 will be merged I moved those changes out.