### PR TITLE
Save all artifacts to disk in the event of failure

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -414,20 +414,22 @@ public func verifySnapshot<Value, Format>(
       let artifactsSubUrl = artifactsUrl.appendingPathComponent(fileName)
       try fileManager.createDirectory(at: artifactsSubUrl, withIntermediateDirectories: true)
 
-      func artifactFileURL(
-        for artifactType: ArtifactType,
-        artifactsDirectory: URL,
-        pathExtension: String
-      ) -> URL {
+      func artifactFileURL(for artifactType: ArtifactType) -> String {
         let baseFileName = "\(testName).\(identifier)"
         let artifactFileName = "\(baseFileName)\(artifactType.suffix)"
         let result = URL(fileURLWithPath: artifactFileName, isDirectory: false)
-        return result.appendingPathExtension(snapshotting.pathExtension ?? "")
+        return result.appendingPathExtension(snapshotting.pathExtension ?? "").path
       }
 
-      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(
-        snapshotFileUrl.lastPathComponent)
+      let failedSnapshotFileUrl = artifactsSubUrl.appendingPathComponent(artifactFileURL(for: .failure))
       try snapshotting.diffing.toData(diffable).write(to: failedSnapshotFileUrl)
+      let referenceSnapshotFileURL = artifactsSubUrl.appendingPathComponent(artifactFileURL(for: .reference))
+      try snapshotting.diffing.toData(reference).write(to: referenceSnapshotFileURL)
+
+      if let diffValue {
+        let diffFileURL = artifactsSubUrl.appendingPathComponent(artifactFileURL(for: .diff))
+        try snapshotting.diffing.toData(diffValue).write(to: diffFileURL)
+      }
 
 
       if !attachments.isEmpty {

--- a/Sources/SnapshotTesting/Diffing.swift
+++ b/Sources/SnapshotTesting/Diffing.swift
@@ -11,7 +11,8 @@ public struct Diffing<Value> {
 
   /// Compares two values. If the values do not match, returns a failure message and artifacts
   /// describing the failure.
-  public var diff: (Value, Value) -> (String, [XCTAttachment])?
+  public typealias DiffingResult = (String, [XCTAttachment], Value?)
+  public var diff: (Value, Value) -> DiffingResult?
 
   /// Creates a new `Diffing` on `Value`.
   ///
@@ -22,7 +23,7 @@ public struct Diffing<Value> {
   public init(
     toData: @escaping (_ value: Value) -> Data,
     fromData: @escaping (_ data: Data) -> Value,
-    diff: @escaping (_ lhs: Value, _ rhs: Value) -> (String, [XCTAttachment])?
+    diff: @escaping (_ lhs: Value, _ rhs: Value) -> DiffingResult?
   ) {
     self.toData = toData
     self.fromData = fromData

--- a/Sources/SnapshotTesting/Internal/Deprecations.swift
+++ b/Sources/SnapshotTesting/Internal/Deprecations.swift
@@ -94,7 +94,7 @@ public func _verifyInlineSnapshot<Value>(
     let trimmedReference = reference.trimmingCharacters(in: .whitespacesAndNewlines)
 
     // Always perform diff, and return early on success!
-    guard let (failure, attachments) = snapshotting.diffing.diff(trimmedReference, diffable) else {
+    guard let (failure, attachments, diffValue) = snapshotting.diffing.diff(trimmedReference, diffable) else {
       return nil
     }
 

--- a/Sources/SnapshotTesting/Snapshotting/Data.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Data.swift
@@ -12,7 +12,7 @@ extension Snapshotting where Value == Data, Format == Data {
           old.count == new.count
           ? "Expected data to match"
           : "Expected \(new) to match \(old)"
-        return (message, [])
+        return (message, [], nil)
       }
     )
   }

--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -33,7 +33,8 @@
         differenceAttachment.name = "difference"
         return (
           message,
-          [oldAttachment, newAttachment, differenceAttachment]
+          [oldAttachment, newAttachment, differenceAttachment],
+          difference
         )
       }
     }

--- a/Sources/SnapshotTesting/Snapshotting/String.swift
+++ b/Sources/SnapshotTesting/Snapshotting/String.swift
@@ -10,20 +10,21 @@ extension Diffing where Value == String {
   /// A line-diffing strategy for UTF-8 text.
   public static let lines = Diffing(
     toData: { Data($0.utf8) },
-    fromData: { String(decoding: $0, as: UTF8.self) }
-  ) { old, new in
-    guard old != new else { return nil }
-    let hunks = chunk(
-      diff: SnapshotTesting.diff(
-        old.split(separator: "\n", omittingEmptySubsequences: false).map(String.init),
-        new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-      ))
-    let failure =
-      hunks
-      .flatMap { [$0.patchMark] + $0.lines }
-      .joined(separator: "\n")
-    let attachment = XCTAttachment(
-      data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
-    return (failure, [attachment])
-  }
+    fromData: { String(decoding: $0, as: UTF8.self) },
+    diff: { old, new in
+      guard old != new else { return nil }
+      let hunks = chunk(
+        diff: SnapshotTesting.diff(
+          old.split(separator: "\n", omittingEmptySubsequences: false).map(String.init),
+          new.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        ))
+      let failure =
+        hunks
+        .flatMap { [$0.patchMark] + $0.lines }
+        .joined(separator: "\n")
+      let attachment = XCTAttachment(
+        data: Data(failure.utf8), uniformTypeIdentifier: "public.patch-file")
+      return (failure, [attachment], nil)
+    }
+  )
 }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -46,7 +46,7 @@
         return (
           message,
           [oldAttachment, newAttachment, differenceAttachment],
-          nil
+          difference
         )
       }
     }

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -45,7 +45,8 @@
         differenceAttachment.name = "difference"
         return (
           message,
-          [oldAttachment, newAttachment, differenceAttachment]
+          [oldAttachment, newAttachment, differenceAttachment],
+          nil
         )
       }
     }


### PR DESCRIPTION
### **Objective:**
In the event of a failing snapshot test, keep in disk artifacts not only for the snapshot that failed, but also for the reference against it was compared to and the diff between them. (Probably sort of what´s being requested in issue #176)

The easiest way I figured out to do this is by adding a third parameter returned by `diff` closure from `Diffing` struct, but of course I´m open to suggestions if there are neater/simpler ways (I explored `XCTestAttachment` since the function is already returning these, but found no way of getting out images from there). 

### **Context**
I´m trying to move away my projects from iOSSnapshotTestCase (previously FBSnapshotTestCase) to this library, since the other ones are no longer maintained and this one seems much more flexible and customizable.

One of the things I´d miss from those libraries though is the ability to get, in the event of failure, all three artifacts, for ease of analysis in CI/CD

### **Experiment ran for verifying**
I created some snapshot tests for a simple view to which I added a red background color. Reference images were generated/recorded with this color. Then changed background color to blue, disabled record mode and ran tests again for them to fail. Resulting folder content is depicted in beneath screenshot

![WhatsApp Image 2024-09-06 at 18 34 28](https://github.com/user-attachments/assets/f5c74f61-61e7-47a4-b2e8-3fe9a88aa547)
