### PR TITLE
Add difftool to verifySnapshot

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -261,6 +261,7 @@ public func assertSnapshots<Value, Format>(
 ///   - snapshotting: A strategy for serializing, deserializing, and comparing values.
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
+///   - diffTool: The diff tool to use while asserting snapshots.
 ///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved
 ///     in a directory with the same name as the test file, and that directory will sit inside a
 ///     directory `__Snapshots__` that sits next to your test file.
@@ -277,6 +278,7 @@ public func verifySnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool? = nil,
+  diffTool: SnapshotTestingConfiguration.DiffTool? = nil,
   snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
@@ -291,7 +293,7 @@ public func verifySnapshot<Value, Format>(
     (recording == true ? .all : recording == false ? .missing : nil)
     ?? SnapshotTestingConfiguration.current?.record
     ?? _record
-  return withSnapshotTesting(record: record) { () -> String? in
+  return withSnapshotTesting(record: record, diffTool: diffTool) { () -> String? in
     do {
       let fileUrl = URL(fileURLWithPath: "\(filePath)", isDirectory: false)
       let fileName = fileUrl.deletingPathExtension().lastPathComponent


### PR DESCRIPTION
Hey folks,
first of all, thanks for all your contributions and effort!

Here's a tiny addition. As wrapping `verifySnapshot` into another `withSnapshotTesting` does not make much sense I added a `diffTool` param that will be passed on.

Let me know if there's something you want me to change. Cheers!