### PR TITLE
Expose `snapshotDirectory` parameter in `assertSnapshot` methods

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -88,6 +88,8 @@ public var __record: SnapshotTestingConfiguration.Record = {
 ///   - snapshotting: A strategy for serializing, deserializing, and comparing values.
 ///   - name: An optional description of the snapshot.
 ///   - recording: Whether or not to record a new reference.
+///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved
+///     in a directory with the same name as the test file, and that directory will sit inside a
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
 ///     which this function was called.
@@ -104,6 +106,7 @@ public func assertSnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record recording: Bool? = nil,
+  snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
   file filePath: StaticString = #filePath,
@@ -116,6 +119,7 @@ public func assertSnapshot<Value, Format>(
     as: snapshotting,
     named: name,
     record: recording,
+    snapshotDirectory: snapshotDirectory,
     timeout: timeout,
     fileID: fileID,
     file: filePath,
@@ -140,6 +144,8 @@ public func assertSnapshot<Value, Format>(
 ///   - strategies: A dictionary of names and strategies for serializing, deserializing, and
 ///     comparing values.
 ///   - recording: Whether or not to record a new reference.
+///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved
+///     in a directory with the same name as the test file, and that directory will sit inside a
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
 ///     which this function was called.
@@ -155,6 +161,7 @@ public func assertSnapshots<Value, Format>(
   of value: @autoclosure () throws -> Value,
   as strategies: [String: Snapshotting<Value, Format>],
   record recording: Bool? = nil,
+  snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
   file filePath: StaticString = #filePath,
@@ -168,6 +175,7 @@ public func assertSnapshots<Value, Format>(
       as: strategy,
       named: name,
       record: recording,
+      snapshotDirectory: snapshotDirectory,
       timeout: timeout,
       fileID: fileID,
       file: filePath,
@@ -184,6 +192,8 @@ public func assertSnapshots<Value, Format>(
 ///   - value: A value to compare against a reference.
 ///   - strategies: An array of strategies for serializing, deserializing, and comparing values.
 ///   - recording: Whether or not to record a new reference.
+///   - snapshotDirectory: Optional directory to save snapshots. By default snapshots will be saved
+///     in a directory with the same name as the test file, and that directory will sit inside a
 ///   - timeout: The amount of time a snapshot must be generated in.
 ///   - fileID: The file ID in which failure occurred. Defaults to the file ID of the test case in
 ///     which this function was called.
@@ -199,6 +209,7 @@ public func assertSnapshots<Value, Format>(
   of value: @autoclosure () throws -> Value,
   as strategies: [Snapshotting<Value, Format>],
   record recording: Bool? = nil,
+  snapshotDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
   file filePath: StaticString = #filePath,
@@ -211,6 +222,7 @@ public func assertSnapshots<Value, Format>(
       of: try value(),
       as: strategy,
       record: recording,
+      snapshotDirectory: snapshotDirectory,
       timeout: timeout,
       fileID: fileID,
       file: filePath,


### PR DESCRIPTION
I'm aware of the intention of the publicly available `verifySnapshot` method that exposes this parameter, but as consumers of the library we tend to use `assertSnapshot` instead.

`assertSnapshot` implementation has a very straightforward implementation that internally uses `verifySnapshot`, but now custom implementations also need to be aware if the custom method is used on a XCTest or SwiftTesting context.

This library already handles that variation, then simply exposing this parameter doesn't break the API and makes sure consumers keep the correct behavior of `assertSnapshots` in context where we need to modify the `snapshotDirectory`, like in Xcode Cloud.