### PR TITLE
Record Attachments in Never mode

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -352,42 +352,69 @@ public func verifySnapshot<Value, Format>(
         return "Couldn't snapshot value"
       }
 
-      func recordSnapshot() throws {
-        try snapshotting.diffing.toData(diffable).write(to: snapshotFileUrl)
+      func recordSnapshot(writeToDisk: Bool) throws {
+        let snapshotData = snapshotting.diffing.toData(diffable)
+
+        if writeToDisk {
+          try snapshotData.write(to: snapshotFileUrl)
+        }
+
         #if !os(Linux) && !os(Windows)
           if !isSwiftTesting,
             ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS")
           {
             XCTContext.runActivity(named: "Attached Recorded Snapshot") { activity in
-              let attachment = XCTAttachment(contentsOfFile: snapshotFileUrl)
-              activity.add(attachment)
+              if writeToDisk {
+                // Snapshot was written to disk. Create attachment from file
+                let attachment = XCTAttachment(contentsOfFile: snapshotFileUrl)
+                activity.add(attachment)
+              } else {
+                // Snapshot was not written to disk. Create attachment from data and path extension
+                let typeIdentifier = snapshotting.pathExtension.flatMap(uniformTypeIdentifier(fromExtension:))
+                
+                let attachment = XCTAttachment(
+                  uniformTypeIdentifier: typeIdentifier,
+                  name: snapshotFileUrl.lastPathComponent,
+                  payload: snapshotData
+                )
+                
+                activity.add(attachment)
+              }
             }
           }
         #endif
       }
 
-      guard
-        record != .all,
-        (record != .missing && record != .failed)
-          || fileManager.fileExists(atPath: snapshotFileUrl.path)
-      else {
-        try recordSnapshot()
+      if record == .all {
+        try recordSnapshot(writeToDisk: true)
 
-        return SnapshotTestingConfiguration.current?.record == .all
-          ? """
+        return """
           Record mode is on. Automatically recorded snapshot: …
 
           open "\(snapshotFileUrl.absoluteString)"
 
           Turn record mode off and re-run "\(testName)" to assert against the newly-recorded snapshot
           """
-          : """
+      }
+
+      guard fileManager.fileExists(atPath: snapshotFileUrl.path) else {
+        if record == .never {
+          try recordSnapshot(writeToDisk: false)
+
+          return """
+          No reference was found on disk. New snapshot was not recorded because recording is disabled
+          """
+        } else {
+          try recordSnapshot(writeToDisk: true)
+
+          return """
           No reference was found on disk. Automatically recorded snapshot: …
 
           open "\(snapshotFileUrl.absoluteString)"
 
           Re-run "\(testName)" to assert against the newly-recorded snapshot.
           """
+        }
       }
 
       let data = try Data(contentsOf: snapshotFileUrl)
@@ -444,7 +471,7 @@ public func verifySnapshot<Value, Format>(
       }
 
       if record == .failed {
-        try recordSnapshot()
+        try recordSnapshot(writeToDisk: true)
         failureMessage += " A new snapshot was automatically recorded."
       }
 
@@ -471,6 +498,17 @@ func sanitizePathComponent(_ string: String) -> String {
     string
     .replacingOccurrences(of: "\\W+", with: "-", options: .regularExpression)
     .replacingOccurrences(of: "^-|-$", with: "", options: .regularExpression)
+}
+
+func uniformTypeIdentifier(fromExtension pathExtension: String) -> String? {
+  // This can be much cleaner in macOS 11+ using UTType
+  let unmanagedString = UTTypeCreatePreferredIdentifierForTag(
+    kUTTagClassFilenameExtension as CFString,
+    pathExtension as CFString,
+    nil
+  )
+
+  return unmanagedString?.takeRetainedValue() as String?
 }
 
 // We need to clean counter between tests executions in order to support test-iterations.

--- a/Tests/SnapshotTestingTests/RecordTests.swift
+++ b/Tests/SnapshotTestingTests/RecordTests.swift
@@ -44,7 +44,7 @@ class RecordTests: XCTestCase {
         }
       } issueMatcher: {
         $0.compactDescription == """
-          failed - The file “testRecordNever.1.json” couldn’t be opened because there is no such file.
+          failed - No reference was found on disk. New snapshot was not recorded because recording is disabled
           """
       }
 


### PR DESCRIPTION
Add XCTAttachment even for `.never` record mode

Context:
https://github.com/pointfreeco/swift-snapshot-testing/discussions/940