### PR TITLE
WKWebView timeout: ensure subscription is not invalidated until isLoading becomes false

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -889,10 +889,10 @@
               var subscription: NSKeyValueObservation?
               subscription = wkWebView.observe(\.isLoading, options: [.initial, .new]) {
                 (webview, change) in
-                subscription?.invalidate()
-                subscription = nil
                 if change.newValue == false {
                   work()
+                  subscription?.invalidate()
+                  subscription = nil
                 }
               }
             } else {


### PR DESCRIPTION
This PR is a fix for #805. 

The current logic stops observing `wkWebView`'s `isLoading` property as soon as the observation handler is called. If the observation is first called when `isLoading` is `true`, the observation is invalidated and the handler will not be called again when `isLoading` flips to false, which leads to timeout errors on iOS. For some reason, on macOS, invalidating the subscription does not seem to prevent the handler being called again once `isLoading` changes to false.

Note: I'd like to be able to verify this fix with tests, but I get transparent images returned on iOS when snapshotting a `WKWebView`. This seems to be related to #857, but even the suggested fix there does not overcome the issue for me.