### PR TITLE
Use alternate means to detect if running on main thread

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -516,24 +516,30 @@ func sanitizePathComponent(_ string: String) -> String {
   }
 #endif
 
+extension DispatchQueue {
+  private static let key = DispatchSpecificKey<UInt8>()
+  private static let value: UInt8 = 0
+
+  fileprivate static func mainSync<R>(execute block: () -> R) -> R {
+    Self.main.setSpecific(key: key, value: value)
+    if getSpecific(key: key) == value {
+      return block()
+    } else {
+      return main.sync(execute: block)
+    }
+  }
+}
+
 // We need to clean counter between tests executions in order to support test-iterations.
 private class CleanCounterBetweenTestCases: NSObject, XCTestObservation {
   private static var registered = false
 
   static func registerIfNeeded() {
-    if Thread.isMainThread {
-      doRegisterIfNeeded()
-    } else {
-      DispatchQueue.main.sync {
-        doRegisterIfNeeded()
+    DispatchQueue.mainSync {
+      if !registered {
+       registered = true
+       XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
       }
-    }
-  }
-
-  private static func doRegisterIfNeeded() {
-    if !registered {
-      registered = true
-      XCTestObservationCenter.shared.addTestObserver(CleanCounterBetweenTestCases())
     }
   }
 

--- a/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
+++ b/Tests/SnapshotTestingTests/AssertSnapshotSwiftTests.swift
@@ -15,4 +15,18 @@
       assertSnapshot(of: user, as: .dump)
     }
   }
+
+  @MainActor
+  @Suite(
+    .snapshots(
+      record: .missing
+    )
+  )
+  struct MainActorTests {
+    @Test func dump() {
+      struct User { let id: Int, name: String, bio: String }
+      let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
+      assertSnapshot(of: user, as: .dump)
+    }
+  }
 #endif

--- a/Tests/SnapshotTestingTests/__Snapshots__/AssertSnapshotSwiftTests/dump.2.txt
+++ b/Tests/SnapshotTestingTests/__Snapshots__/AssertSnapshotSwiftTests/dump.2.txt
@@ -1,0 +1,4 @@
+▿ User
+  - bio: "Blobbed around the world."
+  - id: 1
+  - name: "Blobby"


### PR DESCRIPTION
This is to avoid problems on linux when running `@MainActor` tests.

Resolves issue #919 