### PR TITLE
Add `.customDump` strategy and deprecate `.dump`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,13 @@ jobs:
     strategy:
       matrix:
         swift:
-          - "5.7"
+          - '5.9'
 
-    name: Ubuntu (Swift ${{ matrix.swift }})
-    runs-on: ubuntu-20.04
+    container: swift:${{ matrix.swift }}
+    name: Linux (Swift ${{ matrix.swift }})
+    runs-on: ubuntu-latest
     steps:
-      - uses: swift-actions/setup-swift@v1
-        with:
-          swift-version: ${{ matrix.swift }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: swift test
 
   windows:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,30 @@
 {
   "pins" : [
     {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
         "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
         "version" : "600.0.0-prerelease-2024-06-12"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
+        "version" : "1.4.3"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4c6cc0a3b9e8f14b3ae2307c5ccae4de6167ac2c",
-        "version" : "600.0.0-prerelease-2024-06-12"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.9
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -19,13 +19,28 @@ let package = Package(
       name: "InlineSnapshotTesting",
       targets: ["InlineSnapshotTesting"]
     ),
+    .library(
+      name: "SnapshotTestingCustomDump",
+      targets: ["SnapshotTestingCustomDump"]
+    ),
   ],
   dependencies: [
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease")
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
   ],
   targets: [
     .target(
       name: "SnapshotTesting"
+    ),
+    .testTarget(
+      name: "SnapshotTestingTests",
+      dependencies: [
+        "SnapshotTesting"
+      ],
+      exclude: [
+        "__Fixtures__",
+        "__Snapshots__",
+      ]
     ),
     .target(
       name: "InlineSnapshotTesting",
@@ -42,14 +57,11 @@ let package = Package(
         "InlineSnapshotTesting"
       ]
     ),
-    .testTarget(
-      name: "SnapshotTestingTests",
+    .target(
+      name: "SnapshotTestingCustomDump",
       dependencies: [
-        "SnapshotTesting"
-      ],
-      exclude: [
-        "__Fixtures__",
-        "__Snapshots__",
+        "SnapshotTesting",
+        .product(name: "CustomDump", package: "swift-custom-dump"),
       ]
     ),
   ]

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0-prerelease"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"601.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ let package = Package(
     .testTarget(
       name: "SnapshotTestingTests",
       dependencies: [
-        "SnapshotTesting"
+        "SnapshotTesting",
       ],
       exclude: [
         "__Fixtures__",
@@ -46,6 +46,7 @@ let package = Package(
       name: "InlineSnapshotTesting",
       dependencies: [
         "SnapshotTesting",
+        "SnapshotTestingCustomDump",
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -41,6 +41,11 @@ extension Snapshotting where Format == String {
   ///   - id: 1
   ///   - name: "Blobby"
   /// ```
+  @available(
+    *,
+    deprecated,
+    message: "Use '.customDump' from the 'SnapshotTestingCustomDump' module, instead."
+  )
   public static var dump: Snapshotting {
     return SimplySnapshotting.lines.pullback { snap($0) }
   }

--- a/Sources/SnapshotTesting/Snapshotting/Any.swift
+++ b/Sources/SnapshotTesting/Snapshotting/Any.swift
@@ -42,8 +42,23 @@ extension Snapshotting where Format == String {
   ///   - name: "Blobby"
   /// ```
   @available(
-    *,
-    deprecated,
+    iOS,
+    deprecated: 9999,
+    message: "Use '.customDump' from the 'SnapshotTestingCustomDump' module, instead."
+  )
+  @available(
+    macOS,
+    deprecated: 9999,
+    message: "Use '.customDump' from the 'SnapshotTestingCustomDump' module, instead."
+  )
+  @available(
+    tvOS,
+    deprecated: 9999,
+    message: "Use '.customDump' from the 'SnapshotTestingCustomDump' module, instead."
+  )
+  @available(
+    watchOS,
+    deprecated: 9999,
     message: "Use '.customDump' from the 'SnapshotTestingCustomDump' module, instead."
   )
   public static var dump: Snapshotting {

--- a/Sources/SnapshotTestingCustomDump/CustomDump.swift
+++ b/Sources/SnapshotTestingCustomDump/CustomDump.swift
@@ -1,0 +1,24 @@
+import CustomDump
+import SnapshotTesting
+
+extension Snapshotting where Format == String {
+  /// A snapshot strategy for comparing any structure based on a
+  /// [custom dump](https://github.com/pointfreeco/swift-custom-dump).
+  ///
+  /// ```swift
+  /// assertSnapshot(of: user, as: .customDump)
+  /// ```
+  ///
+  /// Records:
+  ///
+  /// ```
+  /// User(
+  ///   bio: "Blobbed around the world.",
+  ///   id: 1,
+  ///   name: "Blobby"
+  /// )
+  /// ```
+  public static var customDump: Snapshotting {
+    SimplySnapshotting.lines.pullback(String.init(customDumping:))
+  }
+}

--- a/Tests/InlineSnapshotTestingTests/CustomDumpTests.swift
+++ b/Tests/InlineSnapshotTestingTests/CustomDumpTests.swift
@@ -1,0 +1,26 @@
+#if canImport(Testing)
+  import Testing
+  import InlineSnapshotTesting
+  import SnapshotTestingCustomDump
+
+  @Suite(
+    .snapshots(
+      record: .missing
+    )
+  )
+  struct CustomDumpSnapshotTests {
+    @Test func basics() {
+      struct User { let id: Int, name: String, bio: String }
+      let user = User(id: 1, name: "Blobby", bio: "Blobbed around the world.")
+      assertInlineSnapshot(of: user, as: .customDump) {
+        """
+        CustomDumpSnapshotTests.User(
+          id: 1,
+          name: "Blobby",
+          bio: "Blobbed around the world."
+        )
+        """
+      }
+    }
+  }
+#endif


### PR DESCRIPTION
Custom Dump already does a lot of the work the `.dump` strategy does, but also a whole lot more and in a friendlier format.