### PR TITLE
Disable XCTAttachment when using Swift Testing

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -35,6 +35,9 @@
           let message = compare(
             old, new, precision: precision, perceptualPrecision: perceptualPrecision)
         else { return nil }
+        if isSwiftTesting {
+          return (message, [])
+        }
         let difference = SnapshotTesting.diff(old, new)
         let oldAttachment = XCTAttachment(image: old)
         oldAttachment.name = "reference"


### PR DESCRIPTION
Adding the XCTAttachments for UIImage comparisons seems to be way more expensive than the image comparison itself:

<img width="1083" alt="Screenshot 2025-02-04 at 10 41 59" src="https://github.com/user-attachments/assets/91076545-5567-433d-a53b-2e2f46f7d4d7" />

I suggest not adding them when using Swift Testing.