### PR TITLE
Swift Testing: Reset file counter for each test

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -318,7 +318,9 @@ public func verifySnapshot<Value, Format>(
       if let name = name {
         identifier = sanitizePathComponent(name)
       } else {
-        identifier = String(counter.next())
+        identifier = String(
+          counter.next(for: snapshotDirectoryUrl.appendingPathComponent(testName).absoluteString)
+        )
       }
 
       let testName = sanitizePathComponent(testName)
@@ -560,22 +562,22 @@ enum File {
   @TaskLocal static var counter = Counter()
 
   final class Counter: @unchecked Sendable {
-    private var count = 0
+    private var counts: [String: Int] = [:]
     private let lock = NSLock()
 
     init() {}
 
-    func next() -> Int {
+    func next(for key: String) -> Int {
       lock.lock()
       defer { lock.unlock() }
-      count += 1
-      return count
+      counts[key, default: 0] += 1
+      return counts[key]!
     }
 
     func reset() {
       lock.lock()
       defer { lock.unlock() }
-      count = 0
+      counts.removeAll()
     }
   }
 }

--- a/Sources/SnapshotTesting/SnapshotsTestTrait.swift
+++ b/Sources/SnapshotTesting/SnapshotsTestTrait.swift
@@ -9,6 +9,11 @@
 
   extension Trait where Self == _SnapshotsTestTrait {
     /// Configure snapshot testing in a suite or test.
+    public static var snapshots: Self {
+      snapshots()
+    }
+
+    /// Configure snapshot testing in a suite or test.
     ///
     /// - Parameters:
     ///   - record: The record mode of the test.

--- a/Sources/SnapshotTesting/SnapshotsTestTrait.swift
+++ b/Sources/SnapshotTesting/SnapshotsTestTrait.swift
@@ -46,7 +46,9 @@
           record: configuration.record,
           diffTool: configuration.diffTool
         ) {
-          try await function()
+          try await File.$counter.withValue(File.Counter()) {
+            try await function()
+          }
         }
       }
     }


### PR DESCRIPTION
This introduces a new task local to the test scoping trait to allow a test to be repeatedly run.

Fixes #963.