### PR TITLE
Help with file paths that include spaces

### DIFF
--- a/Sources/SnapshotTesting/SnapshotTestingConfiguration.swift
+++ b/Sources/SnapshotTesting/SnapshotTestingConfiguration.swift
@@ -168,7 +168,7 @@ public struct SnapshotTestingConfiguration: Sendable {
 
     /// The [Kaleidoscope](http://kaleidoscope.app) diff tool.
     public static let ksdiff = Self {
-      "ksdiff \($0) \($1)"
+      "ksdiff \"\($0)\" \"\($1)\""
     }
 
     /// The default diff tool.


### PR DESCRIPTION
The error messages for failing tests include ksdiff output to copy/paste into the command line. If you happen to have spaces anywhere in your path structure it fails. This just wraps them so that it launches Kaleidoscope as expected.