### PR TITLE
Using explicit .git URLs for dependencies and installation steps

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "07a521480635f19eb7317262fb971d3ab6c7aab59602add7dd5b3f44a72b1ef7",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
@@ -12,10 +13,10 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -23,10 +24,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "a3f634d1a409c7979cabc0a71b3f26ffa9fc8af1",
-        "version" : "1.4.3"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.3.3"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
   ],
   targets: [
     .target(

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -25,8 +25,8 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.3.3"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.0.0"..<"602.0.0"),
   ],
   targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The latest documentation is available
 
  1. From the **File** menu, navigate through **Swift Packages** and select
     **Add Package Dependency…**.
- 2. Enter package repository URL: `https://github.com/pointfreeco/swift-snapshot-testing`.
+ 2. Enter package repository URL: `https://github.com/pointfreeco/swift-snapshot-testing.git`.
  3. Confirm the version and let Xcode resolve the package.
  4. On the final dialog, update SnapshotTesting's **Add to Target** column to a test target that
     will contain snapshot tests (if you have more than one test target, you can later add
@@ -184,7 +184,7 @@ If you want to use SnapshotTesting in any other project that uses
 ```swift
 dependencies: [
   .package(
-    url: "https://github.com/pointfreeco/swift-snapshot-testing",
+    url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
     from: "1.12.0"
   ),
 ]


### PR DESCRIPTION
Thank you for a great library. 

We are experiencing a tiny annoyance with package resolution. Occasionally, when resolving packages, Xcode would use different URLs for resolution, resulting in constant back-and-forth changes to the `Package.resolved` file. 

```diff
{
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-     "location" : "https://github.com/swiftlang/swift-syntax.git",
+     "location" : "https://github.com/swiftlang/swift-syntax",
```

According to my research, this is an Xcode annoyance where, depending on the local setup or mood 🤷, it would select one URL or another. The solution involves unifying the URLs defined by the project and its dependencies to use a single format. I have checked the installation instructions for swift-syntax, and they suggest using URLs with .git at the end, hence this change. 

I considered starting a conversation about this, but the change is minor, so I decided to do a PR instead. I welcome the conversation and understand that everyone's setup and environment are different, and such a change can be pretty invasive. 

Resources: 
https://forums.swift.org/t/xcode-automatically-updating-package-resolved/41900/6
https://forums.swift.org/t/is-there-is-a-good-reason-to-include-git-in-swift-package-dependency-urls/68800
https://www.reddit.com/r/swift/comments/193opr4/spm_randomly_adds_and_deletes_git_extension_from/