### PR TITLE
fix: default to drawHierarchy rendering when available

### DIFF
--- a/Sources/SnapshotTesting/Documentation.docc/Articles/CustomStrategies.md
+++ b/Sources/SnapshotTesting/Documentation.docc/Articles/CustomStrategies.md
@@ -91,6 +91,48 @@ extension Snapshotting where Value == WKWebView, Format == UIImage {
 }
 ```
 
+## SwiftUI Considerations
+
+When working with SwiftUI views, you can control the rendering method using the `renderingMode` 
+parameter to ensure proper snapshot consistency across different iOS versions and complex shapes.
+
+### Rendering Modes
+
+SwiftUI views with complex shapes (such as `RoundedRectangle` with `.continuous` style) may render 
+differently when using Core Graphics layer rendering versus the system's native drawing hierarchy. 
+The `renderingMode` parameter gives you explicit control over this behavior:
+
+``` swift
+// Default: Automatic detection (recommended)
+assertSnapshot(of: mySwiftUIView, as: .image)
+assertSnapshot(of: mySwiftUIView, as: .image(renderingMode: .auto))
+
+// Always use high-accuracy rendering (requires host application)
+assertSnapshot(of: mySwiftUIView, as: .image(renderingMode: .enabled))
+
+// Always use layer rendering (works in framework tests)
+assertSnapshot(of: mySwiftUIView, as: .image(renderingMode: .disabled))
+```
+
+### Automatic Mode (`.auto`)
+
+The default `.auto` mode intelligently detects SwiftUI content and uses `drawHierarchy` rendering 
+for better accuracy when a key window is available, gracefully falling back to layer rendering 
+in framework test environments.
+
+### Framework Test Compatibility
+
+When using `.auto` mode, the library automatically adapts to framework test environments where 
+no key window is available. For complex SwiftUI views that may have minor rendering differences 
+in framework tests, consider using perceptual precision:
+
+``` swift
+assertSnapshot(of: myView, as: .image(
+  renderingMode: .auto,
+  perceptualPrecision: 0.98  // Allow minor rendering differences
+))
+```
+
 ## Diffing
 
 The ``SnapshotTesting/Diffing`` type represents the ability to compare `Value`s and convert them to

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -26,9 +26,8 @@
       /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.
       ///
       /// - Parameters:
-      ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render
-      ///     `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your
-      ///     tests and will _not_ work for framework test targets.
+      ///   - renderingMode: The rendering mode to use. Defaults to `.auto` which automatically 
+      ///     detects SwiftUI content and uses the most accurate rendering method when possible.
       ///   - precision: The percentage of pixels that must match.
       ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a
       ///     match. 98-99% mimics
@@ -37,7 +36,7 @@
       ///   - layout: A view layout override.
       ///   - traits: A trait collection override.
       public static func image(
-        drawHierarchyInKeyWindow: Bool = false,
+        renderingMode: SwiftUIRenderingMode = .auto,
         precision: Float = 1,
         perceptualPrecision: Float = 1,
         layout: SwiftUISnapshotLayout = .sizeThatFits,
@@ -81,12 +80,44 @@
 
           return snapshotView(
             config: config,
-            drawHierarchyInKeyWindow: drawHierarchyInKeyWindow,
+            renderingMode: renderingMode,
             traits: traits,
             view: controller.view,
             viewController: controller
           )
         }
+      }
+
+      /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.
+      ///
+      /// - Parameters:
+      ///   - drawHierarchyInKeyWindow: Utilize the simulator's key window in order to render
+      ///     `UIAppearance` and `UIVisualEffect`s. This option requires a host application for your
+      ///     tests and will _not_ work for framework test targets.
+      ///   - precision: The percentage of pixels that must match.
+      ///   - perceptualPrecision: The percentage a pixel must match the source pixel to be considered a
+      ///     match. 98-99% mimics
+      ///     [the precision](http://zschuessler.github.io/DeltaE/learn/#toc-defining-delta-e) of the
+      ///     human eye.
+      ///   - layout: A view layout override.
+      ///   - traits: A trait collection override.
+      @available(*, deprecated, message: "Use renderingMode parameter instead")
+      public static func image(
+        drawHierarchyInKeyWindow: Bool,
+        precision: Float = 1,
+        perceptualPrecision: Float = 1,
+        layout: SwiftUISnapshotLayout = .sizeThatFits,
+        traits: UITraitCollection = .init()
+      )
+        -> Snapshotting
+      {
+        return .image(
+          renderingMode: drawHierarchyInKeyWindow ? .enabled : .disabled,
+          precision: precision,
+          perceptualPrecision: perceptualPrecision,
+          layout: layout,
+          traits: traits
+        )
       }
     }
   #endif


### PR DESCRIPTION
Resolves rendering issues (#606, #790) caused by layer.render(in:) no longer matching runtime visuals on iOS 17+. This change uses drawHierarchyInKeyWindow: true when safe (e.g. SwiftUI + key window), preserving CI stability while improving snapshot fidelity.

