### PR TITLE
Relax the protocol requirement for Snapshotting extension

### DIFF
--- a/Sources/SnapshotTesting/Documentation.docc/Articles/CustomStrategies.md
+++ b/Sources/SnapshotTesting/Documentation.docc/Articles/CustomStrategies.md
@@ -22,7 +22,7 @@ Snapshotting<UIView, UIImage>.image
 We can define an `image` strategy on `UIViewController` using the `pullback` method:
 
 ``` swift
-extension Snapshotting where Value == UIViewController, Format == UIImage {
+extension Snapshotting where Value: UIViewController, Format == UIImage {
   public static let image: Snapshotting = Snapshotting<UIView, UIImage>
     .image
     .pullback { viewController in viewController.view }

--- a/Sources/SnapshotTesting/Snapshotting/NSView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSView.swift
@@ -2,7 +2,7 @@
   import AppKit
   import Cocoa
 
-  extension Snapshotting where Value == NSView, Format == NSImage {
+  extension Snapshotting where Value: NSView Format == NSImage {
     /// A snapshot strategy for comparing views based on pixel equality.
     public static var image: Snapshotting {
       return .image()
@@ -47,7 +47,7 @@
     }
   }
 
-  extension Snapshotting where Value == NSView, Format == String {
+  extension Snapshotting where Value: NSView, Format == String {
     /// A snapshot strategy for comparing views based on a recursive description of their properties
     /// and hierarchies.
     ///

--- a/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSViewController.swift
@@ -2,7 +2,7 @@
   import AppKit
   import Cocoa
 
-  extension Snapshotting where Value == NSViewController, Format == NSImage {
+  extension Snapshotting where Value: NSViewController, Format == NSImage {
     /// A snapshot strategy for comparing view controller views based on pixel equality.
     public static var image: Snapshotting {
       return .image()
@@ -26,7 +26,7 @@
     }
   }
 
-  extension Snapshotting where Value == NSViewController, Format == String {
+  extension Snapshotting where Value: NSViewController, Format == String {
     /// A snapshot strategy for comparing view controller views based on a recursive description of
     /// their properties and hierarchies.
     public static var recursiveDescription: Snapshotting {

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
   import UIKit
 
-  extension Snapshotting where Value == UIView, Format == UIImage {
+  extension Snapshotting where Value: UIView, Format == UIImage {
     /// A snapshot strategy for comparing views based on pixel equality.
     public static var image: Snapshotting {
       return .image()
@@ -44,7 +44,7 @@
     }
   }
 
-  extension Snapshotting where Value == UIView, Format == String {
+  extension Snapshotting where Value: UIView, Format == String {
     /// A snapshot strategy for comparing views based on a recursive description of their properties
     /// and hierarchies.
     ///

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -1,7 +1,7 @@
 #if os(iOS) || os(tvOS)
   import UIKit
 
-  extension Snapshotting where Value == UIViewController, Format == UIImage {
+  extension Snapshotting where Value: UIViewController, Format == UIImage {
     /// A snapshot strategy for comparing view controller views based on pixel equality.
     public static var image: Snapshotting {
       return .image()
@@ -83,7 +83,7 @@
     }
   }
 
-  extension Snapshotting where Value == UIViewController, Format == String {
+  extension Snapshotting where Value: UIViewController, Format == String {
     /// A snapshot strategy for comparing view controllers based on their embedded controller
     /// hierarchy.
     ///


### PR DESCRIPTION
When wrapping a custom assert function for SwiftUI.View, we may want to write the following code.

```
#if canImport(AppKit)
typealias PlatformHostingController = NSHostingController
#else
typealias PlatformHostingController = UIHostingController
#endif

func viewAssertSnapshot<V: View, Format>(
    of value: @autoclosure () throws -> V,
    as snapshotting: Snapshotting<PlatformHostingController<V>, Format> = .image,
    ...
) {
    assertSnapshot(
        of: PlatformHostingController(rootView: try value()),
        as: snapshotting,
        named: name,
        record: recording,
        timeout: timeout,
        fileID: fileID,
        file: filePath,
        testName: testName,
        line: line,
        column: column
    )
    ...
}
```

It does not compile now since image extension has a requirement of `Value == UIViewController`.

And the workaround is change `Snapshotting<PlatformHostingController<V>, Format>` to `Snapshotting<UIViewController, Format>`.

I think it is common we define some UIViewController's subclass and use the new subclass as the generic. So I propose we relax the requirement for the common UI extension of Snapshotting.

