### PR TITLE
Only create the directory if it does not exist

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -331,7 +331,9 @@ public func verifySnapshot<Value, Format>(
         snapshotFileUrl = snapshotFileUrl.appendingPathExtension(ext)
       }
       let fileManager = FileManager.default
-      try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)
+      if !fileManager.fileExists(atPath: snapshotDirectoryUrl.path) {
+        try fileManager.createDirectory(at: snapshotDirectoryUrl, withIntermediateDirectories: true)
+      }
 
       let tookSnapshot = XCTestExpectation(description: "Took snapshot")
       var optionalDiffable: Format?


### PR DESCRIPTION
When running in a CI setup using `xcodebuild build-for-testing` / `xcodebuild test-without-running`, the snapshot folder inside the test bundle might not be writable and tests fail because `FileManager.createDirectory()` attempts to create the directory regardless if it exists or not and fails with a permission denied error.

This adds a preflight check and only attempts to create the folder when it doesn't already exist.