### PR TITLE
Improvements to the generated difference image (#520)

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -179,6 +179,11 @@
   }
 
   private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
+    normalizedComponentDiff(old, new)
+    ?? blendModeDiff(old, new)
+  }
+
+  private func blendModeDiff(_ old: UIImage, _ new: UIImage) -> UIImage {
     let width = max(old.size.width, new.size.width)
     let height = max(old.size.height, new.size.height)
     let scale = max(old.scale, new.scale)
@@ -189,6 +194,97 @@
     UIGraphicsEndImageContext()
     return differenceImage
   }
+
+private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage? {
+  guard let oldCgImage = old.cgImage,
+        let pngData = new.pngData(),
+        let newCgImage = UIImage(data: pngData)?.cgImage,
+        oldCgImage.width == newCgImage.width,
+        oldCgImage.height == newCgImage.height,
+        let oldData = oldCgImage.dataProvider?.data,
+        let newData = newCgImage.dataProvider?.data
+  else {
+    return nil
+  }
+  
+  guard let outputColorSpace = CGColorSpace(name: CGColorSpace.linearGray),
+        let outputFormat = vImage_CGImageFormat(
+          bitsPerComponent: imageContextBitsPerComponent,
+          bitsPerPixel: imageContextBitsPerComponent,
+          colorSpace: outputColorSpace,
+          bitmapInfo: .init(),
+        )
+  else {
+    return nil
+  }
+  
+  let width = oldCgImage.width
+  let height = oldCgImage.height
+  let pixelCount = width * height
+  let scale = old.scale
+  
+  let oldBytes = CFDataGetBytePtr(oldData)!
+  let newBytes = CFDataGetBytePtr(newData)!
+  var diffBytes = [UInt8](repeating: 0, count: pixelCount)
+  
+  var index = 0
+  while index < pixelCount {
+    defer { index += 1 }
+    let pixelOffset = index * imageContextBytesPerPixel
+    
+    let rOld = Int16(oldBytes[pixelOffset])
+    let gOld = Int16(oldBytes[pixelOffset + 1])
+    let bOld = Int16(oldBytes[pixelOffset + 2])
+    let aOld = Int16(oldBytes[pixelOffset + 3])
+    
+    let rNew = Int16(newBytes[pixelOffset])
+    let gNew = Int16(newBytes[pixelOffset + 1])
+    let bNew = Int16(newBytes[pixelOffset + 2])
+    let aNew = Int16(newBytes[pixelOffset + 3])
+    
+    let rDiff = abs(rOld - rNew)
+    let gDiff = abs(gOld - gNew)
+    let bDiff = abs(bOld - bNew)
+    let aDiff = abs(aOld - aNew)
+    
+    let maxDiff = max(rDiff, gDiff, bDiff, aDiff)
+    diffBytes[index] = UInt8(maxDiff)
+  }
+  
+  let outputCgImage: CGImage? = diffBytes.withUnsafeMutableBytes { diffPtr in
+    var diffBuffer = vImage_Buffer(
+      data: diffPtr.baseAddress,
+      height: vImagePixelCount(height),
+      width: vImagePixelCount(width),
+      rowBytes: width
+    )
+    
+    do {
+      var normalizedBuffer = try vImage_Buffer(
+        width: width,
+        height: height,
+        bitsPerPixel: UInt32(imageContextBitsPerComponent)
+      )
+      defer { normalizedBuffer.free() }
+      
+      let error = vImageContrastStretch_Planar8(
+        &diffBuffer,
+        &normalizedBuffer,
+        vImage_Flags(kvImageNoFlags)
+      )
+      
+      let buffer = error == kvImageNoError ? normalizedBuffer : diffBuffer
+      
+      return try buffer.createCGImage(format: outputFormat)
+    } catch {
+      return nil
+    }
+  }
+  
+  guard let outputCgImage else { return nil }
+  
+  return UIImage(cgImage: outputCgImage, scale: scale, orientation: .up)
+}
 #endif
 
 #if os(iOS) || os(tvOS) || os(macOS)


### PR DESCRIPTION
This PR improves the generated difference image to make differences much clearer in cases where he alpha component changes or there's only a subtle change in color.

- Fixes #520
- Now shows differences when only the alpha component changes
- Normalizes the difference values to improve contrast in the image
- Falls back to using the difference blend mode when the image size has changed

# Examples

All the images below contain the "reference" "failure" and "difference" images from one test run.

## Alpha only changes

The "reference" is a transparent image containing the word "Hello"
The "failure" is a transparent image with the same size containing the word "World"

### Before

The "difference" image is all black because the alpha component is not considered by the `difference` blend mode.

<img width="632" height="40" alt="before" src="https://github.com/user-attachments/assets/b8ec2d29-82ab-498c-a747-28b383f6d6ce" />

### After

The "difference" image now highlights pixels with changes to their the alpha component.

<img width="632" height="40" alt="after" src="https://github.com/user-attachments/assets/bef30198-63e5-4ca9-9379-3787ca7ef7c3" />

## Subtle color changes

The "reference" image is the color `Color(white: 128.0 / 255.0)`
The "failure" image adds the text "Changed" with the foreground style `Color(white: 129.0 / 255.0)`

### Before

The "difference" is appears all black. The text is so close to the background color, it
s in the "difference" image with a color of `Color(white: 1.0 / 255.0)` which easily not perceptible. You need to adjust the levels in an image editor to really make them visible.

<img width="632" height="40" alt="before" src="https://github.com/user-attachments/assets/380f2b09-bc2f-4b87-ab11-464d9fab4789" />

### After

The "difference" image now clearly shows the difference by normalizing the difference values in the image based on the max component difference per pixel. White is the most different pixel in the image, and black is unchanged pixels.

<img width="632" height="40" alt="after" src="https://github.com/user-attachments/assets/853a93ab-791d-459e-8f14-b2c3d497d6fb" />

