### PR TITLE
Revert "Don't install test observer when in Swift Testing test (#1048)"

### DIFF
--- a/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
+++ b/Sources/InlineSnapshotTesting/AssertInlineSnapshot.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-#if canImport(Testing)
-  import Testing
-#endif
-
 #if canImport(SwiftSyntax509)
   @_spi(Internals) import SnapshotTesting
   import SwiftParser
@@ -344,11 +340,6 @@ public struct InlineSnapshotSyntaxDescriptor: Hashable {
         writeInlineSnapshots()
       }
     }
-    #if canImport(Testing)
-      if Test.current != nil {
-        return
-      }
-    #endif
     if Thread.isMainThread {
       XCTestObservationCenter.shared.addTestObserver(InlineSnapshotObserver())
     } else {


### PR DESCRIPTION
This reverts commit cc051f1c07a414cf36b3d45fc8d00f2a8086ca5e.

This change aimed to fix inline snapshots on Linux, which we still want to do, but it's going to require a bigger change.