### PR TITLE
Use windows from UISceneDelegate lifecycle

### DIFF
--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1076,7 +1076,12 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 13.0, *) {
+      if #available(iOS 15.0, *) {
+        window = UIApplication.sharedIfAvailable?.connectedScenes
+          .compactMap { $0 as? UIWindowScene }
+          .flatMap { $0.windows }
+          .first { $0.isKeyWindow }
+      } else if #available(iOS 13.0, *) {
         window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
       } else {
         window = UIApplication.sharedIfAvailable?.keyWindow
@@ -1090,7 +1095,15 @@
       init(config: ViewImageConfig, viewController: UIViewController) {
         let size = config.size ?? viewController.view.bounds.size
         self.config = config
-        super.init(frame: .init(origin: .zero, size: size))
+
+        // Attach to current window scene to ensure consistent safe area behavior
+        let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive })
+        if #available(iOS 13.0, *), let windowScene = scene as? UIWindowScene {
+          super.init(windowScene: windowScene)
+          self.frame = .init(origin: .zero, size: size)
+        } else {
+          super.init(frame: .init(origin: .zero, size: size))
+        }
 
         // NB: Safe area renders inaccurately for UI{Navigation,TabBar}Controller.
         // Fixes welcome!

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1076,11 +1076,13 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 15.0, *) {
-        window = UIApplication.sharedIfAvailable?.connectedScenes
-          .compactMap { $0 as? UIWindowScene }
-          .flatMap { $0.windows }
-          .first { $0.isKeyWindow }
+      if #available(iOS 13.0, *),
+        let keyWindow = UIApplication.sharedIfAvailable?.connectedScenes
+          .compactMap({ $0 as? UIWindowScene })
+          .flatMap({ $0.windows })
+          .first(where: { $0.isKeyWindow })
+      {
+        window = keyWindow
       } else if #available(iOS 13.0, *) {
         window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
       } else {
@@ -1097,8 +1099,12 @@
         self.config = config
 
         // Attach to current window scene to ensure consistent safe area behavior
-        let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: { $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive })
-        if #available(iOS 13.0, *), let windowScene = scene as? UIWindowScene {
+        if #available(iOS 13.0, *),
+          let scene = UIApplication.sharedIfAvailable?.connectedScenes.first(where: {
+            $0.activationState == .foregroundActive || $0.activationState == .foregroundInactive
+          }),
+          let windowScene = scene as? UIWindowScene
+        {
           super.init(windowScene: windowScene)
           self.frame = .init(origin: .zero, size: size)
         } else {


### PR DESCRIPTION
###  Problem
After migrating to UISceneDelegate lifecycle, snapshot tests failed with pixels mismatch due to incorrect safe area insets being applied. Also other sizing issues appeared which caused fails for currently recorded view's snapshots.

###  Root Cause
The internal Window class was not attached to the active UIWindowScene, causing inconsistent behavior when rendering  views.

### Proposed changes
1. Updated `getKeyWindow()` method
   - Use scene-based window lookup (connectedScenes) on iOS 15+ instead of deprecated UIApplication.shared.windows
2. Updated `Window` class initializer
   - Attach snapshot window to the active UIWindowScene on iOS 13+