### PR TITLE
Fix crash when image reference files do not contain images. 

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -429,7 +429,9 @@ public func verifySnapshot<Value, Format>(
       }
 
       let data = try Data(contentsOf: snapshotFileUrl)
-      let reference = snapshotting.diffing.fromData(data)
+      guard let reference = snapshotting.diffing.fromData(data) else {
+        return "Failed to serialize \(snapshotFileUrl) as \(Format.self)"
+      }
 
       #if os(iOS) || os(tvOS)
         // If the image generation fails for the diffable part and the reference was empty, use the reference

--- a/Sources/SnapshotTesting/Diffing.swift
+++ b/Sources/SnapshotTesting/Diffing.swift
@@ -7,7 +7,7 @@ public struct Diffing<Value> {
   public var toData: (Value) -> Data
 
   /// Produces a value _from_ data.
-  public var fromData: (Data) -> Value
+  public var fromData: (Data) -> Value?
 
   /// Compares two values. If the values do not match, returns a failure message and artifacts
   /// describing the failure.
@@ -21,7 +21,7 @@ public struct Diffing<Value> {
   ///   - diff: A function used to compare two values. If the values do not match, returns a failure
   public init(
     toData: @escaping (_ value: Value) -> Data,
-    fromData: @escaping (_ data: Data) -> Value,
+    fromData: @escaping (_ data: Data) -> Value?,
     diff: @escaping (_ lhs: Value, _ rhs: Value) -> (String, [XCTAttachment])?
   ) {
     self.toData = toData

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -29,7 +29,7 @@
 
       return Diffing(
         toData: { $0.pngData() ?? emptyImage().pngData()! },
-        fromData: { UIImage(data: $0, scale: imageScale)! }
+        fromData: { UIImage(data: $0, scale: imageScale) }
       ) { old, new in
         guard
           let message = compare(

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -1325,6 +1325,22 @@ final class SnapshotTestingTests: BaseTestCase {
       assertSnapshot(of: view, as: .image(layout: .device(config: .tv)), named: "device")
     }
   #endif
+
+#if canImport(UIKit)
+  func testReferenceLoadFailure() throws {
+    let snapshotURL = URL(fileURLWithPath: String(#file), isDirectory: false)
+      .deletingLastPathComponent()
+      .appendingPathComponent("__Snapshots__/SnapshotTestingTests/testReferenceLoadFailure.1.png") // Actually a txt file
+
+    XCTExpectFailure {
+      withSnapshotTesting(record: .failed) {
+        assertSnapshot(of: UIView(frame: CGRect(x: 0, y: 0, width: 10, height: 10)), as: .image)
+      }
+    } issueMatcher: {
+      $0.compactDescription.hasPrefix("failed - Failed to serialize \(snapshotURL) as UIImage")
+    }
+  }
+#endif
 }
 
 #if os(iOS)

--- a/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testReferenceLoadFailure.1.png
+++ b/Tests/SnapshotTestingTests/__Snapshots__/SnapshotTestingTests/testReferenceLoadFailure.1.png
@@ -1,0 +1,8 @@
+version https://git-lfs.github.com/spec/v1
+ <<<<<<< HEAD
+ oid sha256:8f57480096cbd8332496c9465c72eeeab707c5a422152fbd78b9148abb9b112b
+ size 1047456
+ =======
+ oid sha256:0a2ebbcfe842520876e53c1483ea7aa4738ba49177c67a707a3a6b4ac9197c26
+ size 1051011
+ >>>>>>> 6a3fb3bd2 (my-branch-name)


### PR DESCRIPTION
This can happen during a rebase, e.g. we have seen conflicted image paths get updated to contain the following text:

```
version https://git-lfs.github.com/spec/v1
<<<<<<< HEAD
oid sha256:8f57480096cbd8332496c9465c72eeeab707c5a422152fbd78b9148abb9b112b
size 1047456
=======
oid sha256:0a2ebbcfe842520876e53c1483ea7aa4738ba49177c67a707a3a6b4ac9197c26
size 1051011
>>>>>>> 6a3fb3bd2 (my-branch-name)
```

When running tests, crashes cause remaining tests to not be executed. By making this particular crash into a failure instead, we can see all test failures at once and respond to them more effectively!