### PR TITLE
Prefer native Swift Testing image attachments on supported toolchains

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -9,35 +9,6 @@ import XCTest
 
 #if canImport(Testing)
   import Testing
-
-  #if compiler(>=6.2)
-    private func recordSwiftTestingAttachment(
-      _ data: Data,
-      named name: String,
-      sourceLocation: SourceLocation
-    ) {
-      #if compiler(>=6.3)
-        if name.hasSuffix(".png") {
-          #if canImport(UIKit)
-            if #available(iOS 14.0, tvOS 14.0, *) {
-              if let image = UIImage(data: data) {
-                Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
-                return
-              }
-            }
-          #elseif canImport(AppKit)
-            if #available(macOS 11.0, *) {
-              if let image = NSImage(data: data) {
-                Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
-                return
-              }
-            }
-          #endif
-        }
-      #endif
-      Attachment.record(data, named: name, sourceLocation: sourceLocation)
-    }
-  #endif
 #endif
 
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted
@@ -661,3 +632,22 @@ enum File {
     }
   }
 }
+
+#if canImport(Testing) && compiler(>=6.2)
+  private func recordSwiftTestingAttachment(
+    _ data: Data,
+    named name: String,
+    sourceLocation: SourceLocation
+  ) {
+    #if compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))
+      if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *),
+        name.hasSuffix(".png"),
+        let image = Image(data: data)
+      {
+        Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
+        return
+      }
+    #endif
+    Attachment.record(data, named: name, sourceLocation: sourceLocation)
+  }
+#endif

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -1,8 +1,43 @@
 import Foundation
 import XCTest
 
+#if canImport(UIKit)
+  import UIKit
+#elseif canImport(AppKit)
+  import AppKit
+#endif
+
 #if canImport(Testing)
   import Testing
+
+  #if compiler(>=6.2)
+    private func recordSwiftTestingAttachment(
+      _ data: Data,
+      named name: String,
+      sourceLocation: SourceLocation
+    ) {
+      #if compiler(>=6.3)
+        if name.hasSuffix(".png") {
+          #if canImport(UIKit)
+            if #available(iOS 14.0, tvOS 14.0, *) {
+              if let image = UIImage(data: data) {
+                Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
+                return
+              }
+            }
+          #elseif canImport(AppKit)
+            if #available(macOS 11.0, *) {
+              if let image = NSImage(data: data) {
+                Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
+                return
+              }
+            }
+          #endif
+        }
+      #endif
+      Attachment.record(data, named: name, sourceLocation: sourceLocation)
+    }
+  #endif
 #endif
 
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted
@@ -374,7 +409,7 @@ public func verifySnapshot<Value, Format>(
           if ProcessInfo.processInfo.environment.keys.contains("__XCODE_BUILT_PRODUCTS_DIR_PATHS") {
             if isSwiftTesting {
               #if compiler(>=6.2)
-                Attachment.record(
+                recordSwiftTestingAttachment(
                   writeToDisk ? try Data(contentsOf: snapshotFileUrl) : snapshotData,
                   named: snapshotFileUrl.lastPathComponent,
                   sourceLocation: SourceLocation(
@@ -482,7 +517,7 @@ public func verifySnapshot<Value, Format>(
                   case .xcTest:
                     break
                   case .data(let data, let name):
-                    Attachment.record(
+                    recordSwiftTestingAttachment(
                       data,
                       named: name,
                       sourceLocation: SourceLocation(

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -639,15 +639,17 @@ enum File {
     named name: String,
     sourceLocation: SourceLocation
   ) {
-    #if compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))
-      if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *),
-        name.hasSuffix(".png"),
-        let image = Image(data: data)
-      {
-        Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
-        return
-      }
+    #if !os(Android) && !os(Linux) && !os(Windows)
+      #if compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))
+        if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *),
+          name.hasSuffix(".png"),
+          let image = Image(data: data)
+        {
+          Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
+          return
+        }
+      #endif
+      Attachment.record(data, named: name, sourceLocation: sourceLocation)
     #endif
-    Attachment.record(data, named: name, sourceLocation: sourceLocation)
   }
 #endif


### PR DESCRIPTION
This builds on the Swift Testing attachment support added in #1064 and refined in #1065.

Currently, Swift Testing attachments in `AssertSnapshot.swift` are recorded as generic `Data` attachments via `Attachment.record(data, ...)`. On newer toolchains, Swift Testing supports attaching image types directly, so PNG snapshot artifacts can be recorded as native image attachments instead.

This change adds a small helper to prefer native Swift Testing image attachments for PNG snapshot artifacts when supported, while preserving the existing fallback behavior everywhere else.

### What changes

- add a small `recordSwiftTestingAttachment` helper
- for `.png` attachments on supported toolchains:
  - decode the data as `UIImage` / `NSImage`
  - record it with `Attachment.record(..., as: .png, sourceLocation: ...)`
- otherwise fall back to the existing `Attachment.record(data, ...)` path
- update both Swift Testing attachment recording sites to use the helper
- preserve existing `SourceLocation` behavior from #1065

### Notes

- This is a focused enhancement to the existing Swift Testing attachment path.
- Non-image attachments are unchanged.
- Older toolchains continue to use the existing `Data` attachment behavior.
- XCTest behavior is unchanged.

Xcode 26.4 adds native Swift Testing image attachments, so this change aligns SnapshotTesting’s PNG snapshot artifacts with the newer test-reporting API on supported toolchains.