### PR TITLE
Support swift-syntax 603/604; fix compiler crash on Swift 5.9–6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ playground.xcworkspace
 # Packages/
 # Package.pins
 .build/
+.build-*-*
 .swiftpm
 
 # CocoaPods
@@ -68,3 +69,4 @@ fastlane/screenshots
 fastlane/test_output
 
 .DS_Store
+tmp/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,12 @@
 {
-  "originHash" : "6792ede81087f1ebe88912dfc66e1e5b735e65639809682b8e9370dfc1f12b17",
   "pins" : [
     {
       "identity" : "swift-custom-dump",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -24,10 +23,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
-        "version" : "1.6.1"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:6.0
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -26,7 +27,11 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
+    .conditionalPackage(
+      url: "https://github.com/swiftlang/swift-syntax",
+      envVar: "SWIFT_SYNTAX_VERSION",
+      default: "509.0.0..<605.0.0"
+    ),
   ],
   targets: [
     .target(
@@ -68,3 +73,33 @@ let package = Package(
   ],
   swiftLanguageModes: [.v5]
 )
+
+extension Package.Dependency {
+  static func conditionalPackage(
+    url: String,
+    envVar: String,
+    default versionExpression: String
+  ) -> Package.Dependency {
+    let versionRangeString = ProcessInfo.processInfo.environment[envVar] ?? versionExpression
+    let rangeOperators = ["..<", "..."]
+    for op in rangeOperators {
+      if versionRangeString.contains(op) {
+        let parts = versionRangeString.split(separator: op, maxSplits: 1, omittingEmptySubsequences: true)
+          .map(String.init)
+        guard
+          parts.count == 2,
+          let lower = Version(parts[0]),
+          let upper = Version(parts[1])
+        else {
+          fatalError("Invalid version expression format: \(versionRangeString)")
+        }
+        if op == "..<" {
+          return .package(url: url, lower..<upper)
+        } else {
+          return .package(url: url, lower...upper)
+        }
+      }
+    }
+    fatalError("No valid range operator found in expression: \(versionRangeString)")
+  }
+}

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -26,7 +26,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"603.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
     .target(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -1,5 +1,6 @@
 // swift-tools-version:5.9
 
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -26,7 +27,11 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.3"),
-    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
+    .conditionalPackage(
+      url: "https://github.com/swiftlang/swift-syntax",
+      envVar: "SWIFT_SYNTAX_VERSION",
+      default: "509.0.0..<605.0.0"
+    ),
   ],
   targets: [
     .target(
@@ -67,3 +72,33 @@ let package = Package(
     ),
   ]
 )
+
+extension Package.Dependency {
+  static func conditionalPackage(
+    url: String,
+    envVar: String,
+    default versionExpression: String
+  ) -> Package.Dependency {
+    let versionRangeString = ProcessInfo.processInfo.environment[envVar] ?? versionExpression
+    let rangeOperators = ["..<", "..."]
+    for op in rangeOperators {
+      if versionRangeString.contains(op) {
+        let parts = versionRangeString.split(separator: op, maxSplits: 1, omittingEmptySubsequences: true)
+          .map(String.init)
+        guard
+          parts.count == 2,
+          let lower = Version(parts[0]),
+          let upper = Version(parts[1])
+        else {
+          fatalError("Invalid version expression format: \(versionRangeString)")
+        }
+        if op == "..<" {
+          return .package(url: url, lower..<upper)
+        } else {
+          return .package(url: url, lower...upper)
+        }
+      }
+    }
+    fatalError("No valid range operator found in expression: \(versionRangeString)")
+  }
+}

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -211,7 +211,8 @@ private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage?
           bitsPerComponent: imageContextBitsPerComponent,
           bitsPerPixel: imageContextBitsPerComponent,
           colorSpace: outputColorSpace,
-          bitmapInfo: .init(),
+          // NB: No trailing comma — Swift 5.9/5.10/6.0 crash parsing it, even inside #if os(iOS).
+          bitmapInfo: .init()
         )
   else {
     return nil

--- a/bin/setup-podman
+++ b/bin/setup-podman
@@ -1,0 +1,490 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup Podman VM for Linux testing.
+# Interactive by default — guides developers through configuration.
+
+# ============================================================================
+# RAM lookup table (Apple Silicon configurations)
+# ============================================================================
+# Format: "host_gb:recommended_gb:light_gb" (light_gb=0 means no light option)
+readonly RAM_TABLE=(
+  "16:10:0"
+  "24:16:8"
+  "36:24:12"
+  "48:32:16"
+  "64:48:16"
+  "96:72:24"
+  "128:96:32"
+  "192:144:32"
+  "256:192:32"
+  "512:384:48"
+)
+
+# ============================================================================
+# Helper functions
+# ============================================================================
+
+# Lookup RAM configuration, rounding down to nearest tier
+lookup_ram() {
+  local host_gb="$1"
+  local result=""
+
+  for entry in "${RAM_TABLE[@]}"; do
+    IFS=: read -r tier_gb rec_gb light_gb <<< "$entry"
+    if [[ "$host_gb" -ge "$tier_gb" ]]; then
+      result="$entry"
+    fi
+  done
+
+  if [[ -z "$result" ]]; then
+    # Below minimum tier, use smallest
+    result="${RAM_TABLE[0]}"
+  fi
+
+  echo "$result"
+}
+
+# Calculate CPUs for recommended (75% of host, minimum 4)
+calc_cpus_recommended() {
+  local host_cpus="$1"
+  local cpus=$((host_cpus * 3 / 4))
+  if [[ "$cpus" -lt 4 ]]; then
+    cpus=4
+  fi
+  echo "$cpus"
+}
+
+# Calculate CPUs for light (50% of host, minimum 4)
+calc_cpus_light() {
+  local host_cpus="$1"
+  local cpus=$((host_cpus / 2))
+  if [[ "$cpus" -lt 4 ]]; then
+    cpus=4
+  fi
+  echo "$cpus"
+}
+
+# Calculate parallel jobs based on VM resources
+# Uses same formula as bin/test-linux: min(memory/8GB, cpus/3, 8)
+calc_parallel_jobs() {
+  local memory_gb="$1"
+  local cpus="$2"
+
+  local jobs_by_memory=$((memory_gb / 8))
+  local jobs_by_cpus=$((cpus / 3))
+  local max_jobs=8
+
+  local jobs=$jobs_by_memory
+  if [[ "$jobs_by_cpus" -lt "$jobs" ]]; then
+    jobs=$jobs_by_cpus
+  fi
+  if [[ "$max_jobs" -lt "$jobs" ]]; then
+    jobs=$max_jobs
+  fi
+  if [[ "$jobs" -lt 1 ]]; then
+    jobs=1
+  fi
+  echo "$jobs"
+}
+
+# Get current machine state
+get_machine_state() {
+  if ! podman machine inspect &>/dev/null; then
+    echo "none"
+  else
+    local state
+    state=$(podman machine inspect --format '{{.State}}' 2>/dev/null)
+    echo "$state"
+  fi
+}
+
+# Get current machine resources
+get_machine_resources() {
+  local memory_mb cpus
+  memory_mb=$(podman machine inspect --format '{{.Resources.Memory}}' 2>/dev/null) || echo "0"
+  cpus=$(podman machine inspect --format '{{.Resources.CPUs}}' 2>/dev/null) || echo "0"
+  local memory_gb=$((memory_mb / 1024))
+  echo "$memory_gb $cpus"
+}
+
+# Prompt for selection
+prompt_choice() {
+  local prompt="$1"
+  local max="$2"
+  local choice
+
+  while true; do
+    printf "%s" "$prompt" >&2
+    read -r choice
+    if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && [[ "$choice" -ge 1 ]] && [[ "$choice" -le "$max" ]]; then
+      echo "$choice"
+      return
+    fi
+    echo "Please enter a number between 1 and $max" >&2
+  done
+}
+
+# ============================================================================
+# Actions
+# ============================================================================
+
+create_machine() {
+  local memory_mb="$1"
+  local cpus="$2"
+
+  echo ""
+  echo "Creating Podman machine..."
+  podman machine init --memory "$memory_mb" --cpus "$cpus"
+  echo "Starting Podman machine..."
+  podman machine start
+  echo ""
+  echo "✓ Ready"
+}
+
+start_machine() {
+  echo ""
+  echo "Starting Podman machine..."
+  podman machine start
+  echo ""
+  echo "✓ Ready"
+}
+
+stop_machine() {
+  echo ""
+  echo "Stopping Podman machine..."
+  podman machine stop
+  echo ""
+  echo "✓ Stopped"
+}
+
+reconfigure_machine() {
+  local memory_mb="$1"
+  local cpus="$2"
+  local was_running="$3"
+
+  echo ""
+  if [[ "$was_running" == "running" ]]; then
+    echo "Stopping Podman machine..."
+    podman machine stop
+  fi
+  echo "Reconfiguring..."
+  podman machine set --memory "$memory_mb" --cpus "$cpus"
+  echo "Starting Podman machine..."
+  podman machine start
+  echo ""
+  echo "✓ Ready"
+}
+
+delete_machine() {
+  echo ""
+  echo "Deleting Podman machine..."
+  podman machine rm -f
+  echo ""
+  echo "✓ Deleted"
+}
+
+# ============================================================================
+# Interactive flows
+# ============================================================================
+
+flow_no_machine() {
+  local host_gb="$1"
+  local host_cpus="$2"
+  local ram_entry="$3"
+
+  IFS=: read -r tier_gb rec_gb light_gb <<< "$ram_entry"
+  local rec_cpus light_cpus
+  rec_cpus=$(calc_cpus_recommended "$host_cpus")
+  light_cpus=$(calc_cpus_light "$host_cpus")
+
+  local rec_jobs light_jobs
+  rec_jobs=$(calc_parallel_jobs "$rec_gb" "$rec_cpus")
+  light_jobs=$(calc_parallel_jobs "$light_gb" "$light_cpus")
+
+  echo ""
+  echo "Create a Podman machine:"
+  echo ""
+
+  if [[ "$light_gb" -eq 0 ]]; then
+    # Only one option for small machines
+    echo "  [1] Recommended (${rec_gb} GB, ${rec_cpus} CPUs) — ${rec_jobs} parallel job(s)"
+    echo "  [2] Custom"
+    echo ""
+
+    local choice
+    choice=$(prompt_choice "> " 2)
+
+    case "$choice" in
+      1) create_machine "$((rec_gb * 1024))" "$rec_cpus" ;;
+      2) flow_custom "$host_cpus" ;;
+    esac
+  else
+
+    echo "  [1] Recommended (${rec_gb} GB, ${rec_cpus} CPUs) — ${rec_jobs} parallel jobs"
+    echo "  [2] Light (${light_gb} GB, ${light_cpus} CPUs) — ${light_jobs} parallel job(s), frees macOS resources"
+    echo "  [3] Custom"
+    echo ""
+
+    local choice
+    choice=$(prompt_choice "> " 3)
+
+    case "$choice" in
+      1) create_machine "$((rec_gb * 1024))" "$rec_cpus" ;;
+      2) create_machine "$((light_gb * 1024))" "$light_cpus" ;;
+      3) flow_custom "$host_cpus" ;;
+    esac
+  fi
+}
+
+flow_stopped() {
+  local current_gb="$1"
+  local current_cpus="$2"
+  local host_gb="$3"
+  local host_cpus="$4"
+  local ram_entry="$5"
+
+  echo ""
+  echo "  [1] Start"
+  echo "  [2] Reconfigure"
+  echo "  [3] Delete"
+  echo ""
+
+  local choice
+  choice=$(prompt_choice "> " 3)
+
+  case "$choice" in
+    1) start_machine ;;
+    2) flow_reconfigure "$host_gb" "$host_cpus" "$ram_entry" "stopped" ;;
+    3) delete_machine ;;
+  esac
+}
+
+flow_running() {
+  local current_gb="$1"
+  local current_cpus="$2"
+  local host_gb="$3"
+  local host_cpus="$4"
+  local ram_entry="$5"
+
+  echo ""
+  echo "Ready! Run 'bin/test-linux' to test."
+  echo ""
+  echo "Other options:"
+  echo "  [1] Reconfigure (will restart)"
+  echo "  [2] Stop"
+  echo "  [3] Delete"
+  echo ""
+  echo "Press Enter to exit, or choose an option:"
+
+  local choice
+  read -r choice
+
+  case "$choice" in
+    "") exit 0 ;;
+    1) flow_reconfigure "$host_gb" "$host_cpus" "$ram_entry" "running" ;;
+    2) stop_machine ;;
+    3) delete_machine ;;
+    *) exit 0 ;;
+  esac
+}
+
+flow_reconfigure() {
+  local host_gb="$1"
+  local host_cpus="$2"
+  local ram_entry="$3"
+  local was_running="$4"
+
+  IFS=: read -r tier_gb rec_gb light_gb <<< "$ram_entry"
+  local rec_cpus light_cpus
+  rec_cpus=$(calc_cpus_recommended "$host_cpus")
+  light_cpus=$(calc_cpus_light "$host_cpus")
+
+  local rec_jobs light_jobs
+  rec_jobs=$(calc_parallel_jobs "$rec_gb" "$rec_cpus")
+  light_jobs=$(calc_parallel_jobs "$light_gb" "$light_cpus")
+
+  echo ""
+  echo "Reconfigure to:"
+  echo ""
+
+  if [[ "$light_gb" -eq 0 ]]; then
+    echo "  [1] Recommended (${rec_gb} GB, ${rec_cpus} CPUs) — ${rec_jobs} parallel job(s)"
+    echo "  [2] Custom"
+    echo ""
+
+    local choice
+    choice=$(prompt_choice "> " 2)
+
+    case "$choice" in
+      1) reconfigure_machine "$((rec_gb * 1024))" "$rec_cpus" "$was_running" ;;
+      2) flow_custom_reconfigure "$host_cpus" "$was_running" ;;
+    esac
+  else
+
+    echo "  [1] Recommended (${rec_gb} GB, ${rec_cpus} CPUs) — ${rec_jobs} parallel jobs"
+    echo "  [2] Light (${light_gb} GB, ${light_cpus} CPUs) — ${light_jobs} parallel job(s)"
+    echo "  [3] Custom"
+    echo ""
+
+    local choice
+    choice=$(prompt_choice "> " 3)
+
+    case "$choice" in
+      1) reconfigure_machine "$((rec_gb * 1024))" "$rec_cpus" "$was_running" ;;
+      2) reconfigure_machine "$((light_gb * 1024))" "$light_cpus" "$was_running" ;;
+      3) flow_custom_reconfigure "$host_cpus" "$was_running" ;;
+    esac
+  fi
+}
+
+flow_custom() {
+  local host_cpus="$1"
+
+  echo ""
+  printf "Memory (GB): "
+  read -r memory_gb
+  printf "CPUs [default: %d]: " "$(calc_cpus_recommended "$host_cpus")"
+  read -r cpus
+
+  if [[ -z "$cpus" ]]; then
+    cpus=$(calc_cpus_recommended "$host_cpus")
+  fi
+
+  create_machine "$((memory_gb * 1024))" "$cpus"
+}
+
+flow_custom_reconfigure() {
+  local host_cpus="$1"
+  local was_running="$2"
+
+  echo ""
+  printf "Memory (GB): "
+  read -r memory_gb
+  printf "CPUs [default: %d]: " "$(calc_cpus_recommended "$host_cpus")"
+  read -r cpus
+
+  if [[ -z "$cpus" ]]; then
+    cpus=$(calc_cpus_recommended "$host_cpus")
+  fi
+
+  reconfigure_machine "$((memory_gb * 1024))" "$cpus" "$was_running"
+}
+
+# ============================================================================
+# Usage
+# ============================================================================
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Setup Podman VM for Linux testing. Interactive by default.
+
+Options:
+  --auto       Non-interactive: start or create with recommended settings
+  --status     Show current status and exit
+  -h, --help   Show this help
+
+Examples:
+  $(basename "$0")           # Interactive setup
+  $(basename "$0") --auto    # Quick start with recommended settings
+  $(basename "$0") --status  # Check current state
+EOF
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+# Parse arguments
+auto_mode=false
+status_only=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --auto) auto_mode=true; shift ;;
+    --status) status_only=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# Check Podman installation
+if ! command -v podman &>/dev/null; then
+  echo "Podman: ✗ not installed"
+  echo ""
+  echo "Install with:"
+  echo "  brew install podman"
+  exit 1
+fi
+
+podman_version=$(podman --version | awk '{print $3}')
+echo "Podman: ✓ installed ($podman_version)"
+
+# Get host resources
+host_memory_bytes=$(sysctl -n hw.memsize)
+host_gb=$((host_memory_bytes / 1024 / 1024 / 1024))
+host_cpus=$(sysctl -n hw.ncpu)
+
+# Get machine state
+state=$(get_machine_state)
+
+if [[ "$state" == "none" ]]; then
+  echo "Machine: not found"
+else
+  read -r current_gb current_cpus <<< "$(get_machine_resources)"
+  if [[ "$state" == "running" ]]; then
+    echo "Machine: ✓ running (${current_gb} GB, ${current_cpus} CPUs)"
+  else
+    echo "Machine: stopped (${current_gb} GB, ${current_cpus} CPUs)"
+  fi
+fi
+
+echo ""
+echo "Host: ${host_gb} GB RAM, ${host_cpus} CPUs"
+
+# Status only mode
+if [[ "$status_only" == true ]]; then
+  exit 0
+fi
+
+# Lookup RAM configuration
+ram_entry=$(lookup_ram "$host_gb")
+IFS=: read -r tier_gb rec_gb light_gb <<< "$ram_entry"
+
+# Auto mode
+if [[ "$auto_mode" == true ]]; then
+  rec_cpus=$(calc_cpus_recommended "$host_cpus")
+
+  case "$state" in
+    none)
+      echo ""
+      echo "Creating with recommended settings (${rec_gb} GB, ${rec_cpus} CPUs)..."
+      create_machine "$((rec_gb * 1024))" "$rec_cpus"
+      ;;
+    running)
+      echo ""
+      echo "✓ Ready"
+      ;;
+    *)
+      echo ""
+      echo "Starting..."
+      start_machine
+      ;;
+  esac
+  exit 0
+fi
+
+# Interactive mode
+case "$state" in
+  none)
+    flow_no_machine "$host_gb" "$host_cpus" "$ram_entry"
+    ;;
+  running)
+    flow_running "$current_gb" "$current_cpus" "$host_gb" "$host_cpus" "$ram_entry"
+    ;;
+  *)
+    flow_stopped "$current_gb" "$current_cpus" "$host_gb" "$host_cpus" "$ram_entry"
+    ;;
+esac

--- a/bin/test-linux
+++ b/bin/test-linux
@@ -1,0 +1,637 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Test Swift × swift-syntax combinations on Linux via Podman.
+#
+# swift-syntax versions specify a minimum Swift version (swift-tools-version), not an
+# exclusive pairing. For example, swift-syntax 509.x requires Swift 5.7+, meaning it
+# can be used with Swift 5.9, 6.0, 6.1, etc. Users may pin to older swift-syntax
+# versions while using newer Swift compilers.
+#
+# Older Swift compilers (5.9, 5.10, 6.0) parse source inside #if branches that
+# evaluate to false, so syntax errors in platform-gated code (e.g., #if os(iOS))
+# can crash compilation even on Linux. This script verifies the fix.
+
+readonly SWIFT_VERSIONS=(5.9 5.10 6.0 6.1 6.2)
+readonly SYNTAX_VERSIONS=(509 510 600 601 602 603 604)
+readonly MAX_RETRIES=2  # Retry transient compiler crashes
+
+# Detect if stdout is a terminal (for status line updates)
+if [[ -t 1 ]]; then
+  IS_TTY=true
+else
+  IS_TTY=false
+fi
+
+# Check if output indicates a transient failure worth retrying:
+# - git clone/fetch failures (network issues, TLS disconnects)
+# Note: compiler crashes (error: fatalError) are NOT retried — they are almost
+# always caused by real source issues, and retrying masks permanent failures.
+is_transient_failure() {
+  local output_file="$1"
+  grep -qE "Failed to clone repository|RPC failed" \
+    "$output_file" 2>/dev/null
+}
+
+# Detect optimal parallel jobs from Podman VM resources
+# Outputs: "jobs memory_gb" (e.g., "6 144")
+detect_parallel_jobs() {
+  local memory_mb cpus
+  memory_mb=$(podman machine inspect --format '{{.Resources.Memory}}' 2>/dev/null) || return 1
+  cpus=$(podman machine inspect --format '{{.Resources.CPUs}}' 2>/dev/null) || cpus=4
+  if [[ -z "$memory_mb" || "$memory_mb" -lt 1 ]]; then
+    return 1
+  fi
+  local memory_gb=$((memory_mb / 1024))
+  local jobs_by_memory=$((memory_mb / 8192))
+  local jobs_by_cpus=$((cpus / 3))
+  local max_jobs=8
+
+  local jobs=$jobs_by_memory
+  if [[ "$jobs_by_cpus" -lt "$jobs" ]]; then
+    jobs=$jobs_by_cpus
+  fi
+  if [[ "$max_jobs" -lt "$jobs" ]]; then
+    jobs=$max_jobs
+  fi
+  if [[ "$jobs" -lt 1 ]]; then
+    jobs=1
+  fi
+  echo "$jobs $memory_gb"
+}
+
+# Map short syntax version to range
+syntax_range() {
+  case "$1" in
+    509) echo "509.0.0..<510.0.0" ;;
+    510) echo "510.0.0..<511.0.0" ;;
+    600) echo "600.0.0..<601.0.0" ;;
+    601) echo "601.0.0..<602.0.0" ;;
+    602) echo "602.0.0..<603.0.0" ;;
+    603) echo "603.0.0..<604.0.0" ;;
+    604) echo "604.0.0-prerelease..<605.0.0" ;;
+    *) echo "Unknown syntax version: $1" >&2; exit 1 ;;
+  esac
+}
+
+# Expand partial Swift version (6 → 6.0 6.1 6.2)
+expand_swift_version() {
+  local pattern="$1"
+  local matches=()
+  for v in "${SWIFT_VERSIONS[@]}"; do
+    if [[ "$v" == "$pattern"* ]]; then
+      matches+=("$v")
+    fi
+  done
+  if [[ ${#matches[@]} -eq 0 ]]; then
+    echo "No Swift versions match: $pattern" >&2
+    exit 1
+  fi
+  echo "${matches[@]}"
+}
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Test Swift × swift-syntax combinations on Linux via Podman.
+
+Options:
+  --swift VERSION        Swift version(s) to test (e.g., 5.9, 6, 6.1)
+                         Can be specified multiple times. Partial matching supported.
+  --swift-syntax VERSION swift-syntax version(s) to test (e.g., 509, 600)
+                         Can be specified multiple times.
+  --parallel [N|auto]    Run up to N tests concurrently (default: auto)
+                         'auto' detects optimal parallelism from Podman VM memory
+  --sequential           Run tests sequentially (default behavior)
+  --dry-run              Don't run tests, just show what would run
+  --verbose              Show full test output
+  --log-dir DIR          Write test output to files in DIR
+  --continue-on-error    Continue testing after failures
+  -h, --help             Show this help
+
+Examples:
+  $(basename "$0")                              # Full matrix
+  $(basename "$0") --swift 5.9 --swift-syntax 509
+  $(basename "$0") --swift 6                    # All Swift 6.x versions
+  $(basename "$0") --dry-run                    # Preview without running
+  $(basename "$0") --parallel                   # Auto-detect parallelism
+  $(basename "$0") --parallel 8                 # 8 concurrent jobs
+  $(basename "$0") --parallel --continue-on-error
+
+Requires: podman machine start
+EOF
+}
+
+# Parse arguments
+swift_filters=()
+syntax_filters=()
+dry_run=false
+verbose=false
+log_dir=""
+continue_on_error=false
+parallel_jobs=0  # 0 means sequential
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --swift) swift_filters+=("$2"); shift 2 ;;
+    --swift-syntax) syntax_filters+=("$2"); shift 2 ;;
+    --dry-run) dry_run=true; shift ;;
+    --verbose) verbose=true; shift ;;
+    --log-dir) log_dir="$2"; shift 2 ;;
+    --continue-on-error) continue_on_error=true; shift ;;
+    --sequential) parallel_jobs=0; shift ;;
+    --parallel)
+      if [[ $# -gt 1 && "$2" =~ ^[0-9]+$ ]]; then
+        parallel_jobs="$2"
+        if [[ "$parallel_jobs" -lt 1 ]]; then
+          echo "Error: --parallel requires a positive integer" >&2
+          exit 1
+        fi
+        shift 2
+      elif [[ $# -gt 1 && "$2" == "auto" ]]; then
+        parallel_jobs="auto"
+        shift 2
+      else
+        parallel_jobs="auto"
+        shift
+      fi
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+# Warn about verbose + parallel
+if [[ "$verbose" == true && "$parallel_jobs" != "0" ]]; then
+  echo "Warning: --verbose with --parallel may produce interleaved output" >&2
+fi
+
+# Determine versions to test
+if [[ ${#swift_filters[@]} -eq 0 ]]; then
+  swift_to_test=("${SWIFT_VERSIONS[@]}")
+else
+  swift_to_test=()
+  for filter in "${swift_filters[@]}"; do
+    for v in $(expand_swift_version "$filter"); do
+      swift_to_test+=("$v")
+    done
+  done
+fi
+
+if [[ ${#syntax_filters[@]} -eq 0 ]]; then
+  syntax_to_test=("${SYNTAX_VERSIONS[@]}")
+else
+  syntax_to_test=("${syntax_filters[@]}")
+fi
+
+# Build combination list
+combinations=()
+for swift_ver in "${swift_to_test[@]}"; do
+  for syntax_ver in "${syntax_to_test[@]}"; do
+    combinations+=("${swift_ver}:${syntax_ver}")
+  done
+done
+
+total=${#combinations[@]}
+
+if [[ "$dry_run" == true ]]; then
+  echo "Would run $total combination(s):"
+  for combo in "${combinations[@]}"; do
+    IFS=: read -r swift_ver syntax_ver <<< "$combo"
+    echo "  Swift $swift_ver × swift-syntax $syntax_ver"
+  done
+  echo ""
+  if [[ "$parallel_jobs" == "0" ]]; then
+    echo "Mode: sequential"
+  elif [[ "$parallel_jobs" == "auto" ]]; then
+    echo "Mode: parallel (auto-detect)"
+  else
+    echo "Mode: parallel ($parallel_jobs concurrent jobs)"
+  fi
+  exit 0
+fi
+
+# Pre-flight checks
+if ! command -v podman &>/dev/null; then
+  echo "Error: Podman is not installed." >&2
+  echo "" >&2
+  echo "Install with:" >&2
+  echo "  brew install podman" >&2
+  echo "" >&2
+  echo "Then setup a VM with:" >&2
+  echo "  bin/setup-podman" >&2
+  exit 1
+fi
+
+if ! podman info &>/dev/null; then
+  echo "Error: Podman is not running." >&2
+  echo "" >&2
+  echo "Start Podman with:" >&2
+  echo "  podman machine start" >&2
+  echo "" >&2
+  echo "Or setup a new VM with:" >&2
+  echo "  bin/setup-podman" >&2
+  exit 1
+fi
+
+# Resolve "auto" parallel jobs from Podman VM memory
+if [[ "$parallel_jobs" == "auto" ]]; then
+  if detected=$(detect_parallel_jobs); then
+    read -r parallel_jobs memory_gb <<< "$detected"
+    echo "Auto-detected $parallel_jobs parallel jobs (${memory_gb} GB Podman VM)"
+  else
+    parallel_jobs=4
+    echo "Could not detect Podman VM memory, defaulting to $parallel_jobs parallel jobs"
+  fi
+fi
+
+# Prepare log directory with timestamped subdirectory
+if [[ -n "$log_dir" ]]; then
+  timestamp=$(date +%Y-%m-%d_%H%M%S)
+  log_dir="$log_dir/$timestamp"
+  mkdir -p "$log_dir"
+  echo "Logging to: $log_dir"
+fi
+
+# ============================================================================
+# Sequential execution (default)
+# ============================================================================
+run_sequential() {
+  local passed=0
+  local failed=0
+  local failed_combos=()
+
+
+
+  for i in "${!combinations[@]}"; do
+    combo="${combinations[$i]}"
+    IFS=: read -r swift_ver syntax_ver <<< "$combo"
+    syntax_range_val=$(syntax_range "$syntax_ver")
+
+    progress="[$((i + 1))/$total]"
+    label="Swift $swift_ver × swift-syntax $syntax_ver"
+
+    printf "%s %s ... " "$progress" "$label"
+
+    # Mount source read-only, copy into container for full isolation.
+    # Each container gets its own Package.resolved and .build — no shared state.
+    cmd=(
+      podman run --rm
+      -v "$(pwd)":/source:ro
+      -e "SWIFT_SYNTAX_VERSION=$syntax_range_val"
+      "swift:$swift_ver"
+      bash -c "mkdir -p /workspace && cp -a /source/. /workspace/ && cd /workspace && rm -f Package.resolved && swift test"
+    )
+
+    local attempt=0
+    local test_passed=false
+
+    while [[ "$attempt" -lt "$MAX_RETRIES" ]]; do
+      ((attempt++)) || true
+
+      local log_file=""
+      if [[ -n "$log_dir" ]]; then
+        log_file="$log_dir/swift-${swift_ver}_syntax-${syntax_ver}_attempt-${attempt}.log"
+      fi
+
+      if [[ "$verbose" == true ]]; then
+        if [[ "$attempt" -gt 1 ]]; then
+          printf "%s %s (retry %d/%d) ... " "$progress" "$label" "$attempt" "$MAX_RETRIES"
+        fi
+        echo ""
+        tmp_output=$(mktemp)
+        if "${cmd[@]}" 2>&1 | tee "$tmp_output"; then
+          echo "✓ $label passed"
+          test_passed=true
+          if [[ -n "$log_file" ]]; then
+            mv "$tmp_output" "$log_file"
+          else
+            rm -f "$tmp_output"
+          fi
+          break
+        else
+          if is_transient_failure "$tmp_output" && [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
+            echo "⟳ $label transient failure, retrying in 5s..."
+            if [[ -n "$log_file" ]]; then
+              mv "$tmp_output" "$log_file"
+            else
+              rm -f "$tmp_output"
+            fi
+            sleep 5
+          else
+            echo "✗ $label FAILED"
+            if [[ -n "$log_file" ]]; then
+              mv "$tmp_output" "$log_file"
+            else
+              rm -f "$tmp_output"
+            fi
+          fi
+        fi
+      else
+        tmp_output=$(mktemp)
+        if "${cmd[@]}" > "$tmp_output" 2>&1; then
+          if [[ "$attempt" -gt 1 ]]; then
+            echo "✓ (retry $attempt)"
+          else
+            echo "✓"
+          fi
+          test_passed=true
+          if [[ -n "$log_file" ]]; then
+            mv "$tmp_output" "$log_file"
+          else
+            rm "$tmp_output"
+          fi
+          break
+        else
+          if is_transient_failure "$tmp_output" && [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
+            printf "⟳ retry %d (in 5s)... " "$((attempt + 1))"
+            if [[ -n "$log_file" ]]; then
+              mv "$tmp_output" "$log_file"
+            else
+              rm -f "$tmp_output"
+            fi
+            sleep 5
+          else
+            if [[ "$attempt" -gt 1 ]]; then
+              echo "✗ FAILED (after $attempt attempts)"
+            else
+              echo "✗ FAILED"
+            fi
+
+            if [[ -n "$log_file" ]]; then
+              mv "$tmp_output" "$log_file"
+              echo "  Log: $log_file"
+            else
+              echo "  Last 20 lines of output:"
+              tail -20 "$tmp_output" | sed 's/^/    /'
+              rm "$tmp_output"
+            fi
+          fi
+        fi
+      fi
+    done
+
+    if [[ "$test_passed" == true ]]; then
+      ((passed++)) || true
+    else
+      ((failed++)) || true
+      failed_combos+=("$label")
+      if [[ "$continue_on_error" != true ]]; then
+        echo ""
+        echo "Stopping on first failure. Use --continue-on-error to run all."
+        break
+      fi
+    fi
+  done
+
+  echo ""
+  echo "Results: $passed passed, $failed failed (of $total)"
+
+  if [[ $failed -gt 0 ]]; then
+    echo ""
+    echo "Failed combinations:"
+    for combo in "${failed_combos[@]}"; do
+      echo "  - $combo"
+    done
+    echo ""
+    echo "Re-run a specific failure with:"
+    echo "  $(basename "$0") --swift <version> --swift-syntax <version> --verbose"
+    exit 1
+  fi
+}
+
+# ============================================================================
+# Parallel execution
+# ============================================================================
+run_parallel() {
+  local max_jobs="$parallel_jobs"
+
+  local state_dir
+  state_dir=$(mktemp -d)
+  cleanup_parallel() {
+    [[ -n "${state_dir:-}" ]] && rm -rf "$state_dir"
+  }
+  trap cleanup_parallel EXIT
+
+  local queue_file="$state_dir/queue"
+  local running_file="$state_dir/running"
+  local results_file="$state_dir/results"
+  local stop_file="$state_dir/stop"
+
+  printf "%s\n" "${combinations[@]}" > "$queue_file"
+  touch "$running_file" "$results_file"
+
+  echo "0" > "$state_dir/passed"
+  echo "0" > "$state_dir/failed"
+
+  declare -A job_pids=()
+  declare -A job_combos=()
+  declare -A job_outputs=()
+
+  local retries_dir="$state_dir/retries"
+  mkdir -p "$retries_dir"
+
+  get_retry_count() {
+    local combo="$1"
+    local file="$retries_dir/${combo//:/_}"
+    if [[ -f "$file" ]]; then
+      cat "$file"
+    else
+      echo "1"
+    fi
+  }
+
+  increment_retry_count() {
+    local combo="$1"
+    local file="$retries_dir/${combo//:/_}"
+    local current
+    current=$(get_retry_count "$combo")
+    echo "$((current + 1))" > "$file"
+  }
+
+  update_status() {
+    [[ "$IS_TTY" == true ]] || return 0
+    local running=${#job_pids[@]}
+    local passed=$(cat "$state_dir/passed")
+    local failed=$(cat "$state_dir/failed")
+    local completed=$((passed + failed))
+    local queued=$((total - completed - running))
+
+    printf "\r\033[K[%d running, %d passed, %d failed, %d queued]" \
+      "$running" "$passed" "$failed" "$queued"
+  }
+
+  process_completed_job() {
+    local pid="$1"
+    local exit_code="$2"
+    local combo="${job_combos[$pid]}"
+    local output_file="${job_outputs[$pid]}"
+
+    IFS=: read -r swift_ver syntax_ver <<< "$combo"
+    local label="Swift $swift_ver × swift-syntax $syntax_ver"
+    local attempt
+    attempt=$(get_retry_count "$combo")
+
+    grep -v "^${combo}$" "$running_file" > "$running_file.tmp" 2>/dev/null || true
+    mv "$running_file.tmp" "$running_file" 2>/dev/null || true
+
+    [[ "$IS_TTY" == true ]] && printf "\r\033[K"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+      if [[ "$attempt" -gt 1 ]]; then
+        echo "✓ $label (retry $attempt)"
+      else
+        echo "✓ $label"
+      fi
+      local passed=$(cat "$state_dir/passed")
+      echo "$((passed + 1))" > "$state_dir/passed"
+
+      local log_file_name="swift-${swift_ver}_syntax-${syntax_ver}_attempt-${attempt}.log"
+      if [[ -n "$log_dir" ]]; then
+        mv "$output_file" "$log_dir/$log_file_name" 2>/dev/null || true
+      else
+        rm -f "$output_file"
+      fi
+    else
+      if is_transient_failure "$output_file" && [[ "$attempt" -lt "$MAX_RETRIES" ]]; then
+        echo "⟳ $label transient failure (attempt $attempt/$MAX_RETRIES), re-queuing..."
+
+        local log_file_name="swift-${swift_ver}_syntax-${syntax_ver}_attempt-${attempt}.log"
+        if [[ -n "$log_dir" ]]; then
+          mv "$output_file" "$log_dir/$log_file_name" 2>/dev/null || true
+        else
+          rm -f "$output_file"
+        fi
+
+        increment_retry_count "$combo"
+        echo "$combo" >> "$queue_file"
+      else
+        if [[ "$attempt" -gt 1 ]]; then
+          echo "✗ $label FAILED (after $attempt attempts)"
+        else
+          echo "✗ $label FAILED"
+        fi
+        local failed_count=$(cat "$state_dir/failed")
+        echo "$((failed_count + 1))" > "$state_dir/failed"
+        echo "$label" >> "$results_file"
+
+        local log_file_name="swift-${swift_ver}_syntax-${syntax_ver}_attempt-${attempt}.log"
+        if [[ -n "$log_dir" ]]; then
+          mv "$output_file" "$log_dir/$log_file_name" 2>/dev/null || true
+          echo "  Log: $log_dir/$log_file_name"
+        else
+          if [[ -f "$output_file" ]]; then
+            echo "  Last 20 lines of output:"
+            tail -20 "$output_file" | sed 's/^/    /'
+          fi
+          rm -f "$output_file"
+        fi
+
+        if [[ "$continue_on_error" != true ]]; then
+          touch "$stop_file"
+        fi
+      fi
+    fi
+
+    unset "job_pids[$pid]"
+    unset "job_combos[$pid]"
+    unset "job_outputs[$pid]"
+  }
+
+  while true; do
+    if [[ -f "$stop_file" ]]; then
+      for pid in "${!job_pids[@]}"; do
+        wait "$pid" 2>/dev/null && exit_code=0 || exit_code=$?
+        process_completed_job "$pid" "$exit_code"
+      done
+      break
+    fi
+
+    for pid in "${!job_pids[@]}"; do
+      if ! kill -0 "$pid" 2>/dev/null; then
+        wait "$pid" 2>/dev/null && exit_code=0 || exit_code=$?
+        process_completed_job "$pid" "$exit_code"
+      fi
+    done
+
+    local running_count=${#job_pids[@]}
+    while [[ "$running_count" -lt "$max_jobs" ]]; do
+      if [[ ! -s "$queue_file" ]]; then
+        break
+      fi
+
+      local combo
+      combo=$(head -1 "$queue_file")
+      tail -n +2 "$queue_file" > "$queue_file.tmp"
+      mv "$queue_file.tmp" "$queue_file"
+
+      if [[ -f "$stop_file" ]]; then
+        break
+      fi
+
+      IFS=: read -r swift_ver syntax_ver <<< "$combo"
+      local syntax_range_val
+      syntax_range_val=$(syntax_range "$syntax_ver")
+
+      echo "$combo" >> "$running_file"
+
+      local output_file="$state_dir/output_${swift_ver}_${syntax_ver}"
+
+      # Mount source read-only, copy into container for full isolation.
+      # Each container gets its own Package.resolved and .build — no shared state.
+      (
+        podman run --rm \
+          -v "$(pwd)":/source:ro \
+          -e "SWIFT_SYNTAX_VERSION=$syntax_range_val" \
+          "swift:$swift_ver" \
+          bash -c "mkdir -p /workspace && cp -a /source/. /workspace/ && cd /workspace && rm -f Package.resolved && swift test"
+      ) > "$output_file" 2>&1 &
+
+      local pid=$!
+      job_pids[$pid]=1
+      job_combos[$pid]="$combo"
+      job_outputs[$pid]="$output_file"
+
+      ((running_count++)) || true
+    done
+
+    update_status
+
+    if [[ ${#job_pids[@]} -eq 0 && ! -s "$queue_file" ]]; then
+      break
+    fi
+
+    sleep 0.1
+  done
+
+  [[ "$IS_TTY" == true ]] && printf "\r\033[K"
+
+  local passed=$(cat "$state_dir/passed")
+  local failed=$(cat "$state_dir/failed")
+
+  echo ""
+  echo "Results: $passed passed, $failed failed (of $total)"
+
+  if [[ "$failed" -gt 0 ]]; then
+    echo ""
+    echo "Failed combinations:"
+    while IFS= read -r combo; do
+      echo "  - $combo"
+    done < "$results_file"
+    echo ""
+    echo "Re-run a specific failure with:"
+    echo "  $(basename "$0") --swift <version> --swift-syntax <version> --verbose"
+    exit 1
+  fi
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+if [[ "$parallel_jobs" -gt 0 ]]; then
+  echo "Running $total combinations with $parallel_jobs parallel jobs..."
+  run_parallel
+else
+  run_sequential
+fi


### PR DESCRIPTION
## Summary

- Bump swift-syntax dependency range from `<603.0.0` to `<605.0.0` in **both** `Package.swift` and `Package@swift-5.9.swift`
- Fix trailing comma in `UIImage.swift` that crashes Swift 5.9/5.10/6.0 compilers

The trailing comma fix is necessary because older Swift compilers parse source inside `#if` branches that evaluate to false (e.g., `#if os(iOS)` on Linux). Trailing comma support ([SE-0439](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0439-trailing-comma-lists.md)) was implemented in Swift 6.1, so older compilers crash when encountering it — even in dead code branches.

The version bump is the same as #1074. This PR additionally fixes the trailing comma that would otherwise crash Swift 5.9–6.0 compilers, and includes optional testing infrastructure to verify the fix.

## Testing

Verified the full 35-combination matrix (5 Swift versions × 7 swift-syntax versions) on Linux via Podman.

### Before (trailing comma present): 21 failed, 14 passed

Swift 5.9, 5.10, and 6.0 crash with `error: fatalError` across all swift-syntax versions. Swift 6.1+ passes (trailing comma support via SE-0439).

| | 509 | 510 | 600 | 601 | 602 | 603 | 604 |
|---|---|---|---|---|---|---|---|
| **Swift 5.9** | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
| **Swift 5.10** | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
| **Swift 6.0** | :x: | :x: | :x: | :x: | :x: | :x: | :x: |
| **Swift 6.1** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **Swift 6.2** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

<details>
<summary>Full output (before fix)</summary>

```
$ bin/test-linux --parallel --continue-on-error --log-dir ./tmp
Auto-detected 6 parallel jobs (144 GB Podman VM)
Logging to: ./tmp/2026-03-29_190654
Running 35 combinations with 6 parallel jobs...
✗ Swift 5.9 × swift-syntax 603 FAILED
✗ Swift 5.9 × swift-syntax 600 FAILED
✗ Swift 5.9 × swift-syntax 510 FAILED
✗ Swift 5.9 × swift-syntax 509 FAILED
✗ Swift 5.9 × swift-syntax 601 FAILED
✗ Swift 5.9 × swift-syntax 602 FAILED
✗ Swift 5.10 × swift-syntax 509 FAILED
✗ Swift 5.9 × swift-syntax 604 FAILED
✗ Swift 5.10 × swift-syntax 510 FAILED
✗ Swift 5.10 × swift-syntax 600 FAILED
✗ Swift 5.10 × swift-syntax 601 FAILED
✗ Swift 5.10 × swift-syntax 602 FAILED
✗ Swift 5.10 × swift-syntax 603 FAILED
✗ Swift 5.10 × swift-syntax 604 FAILED
✗ Swift 6.0 × swift-syntax 509 FAILED
✗ Swift 6.0 × swift-syntax 510 FAILED
✗ Swift 6.0 × swift-syntax 600 FAILED
✗ Swift 6.0 × swift-syntax 601 FAILED
✗ Swift 6.0 × swift-syntax 602 FAILED
✗ Swift 6.0 × swift-syntax 603 FAILED
✗ Swift 6.0 × swift-syntax 604 FAILED
✓ Swift 6.1 × swift-syntax 510
✓ Swift 6.1 × swift-syntax 601
✓ Swift 6.1 × swift-syntax 600
✓ Swift 6.1 × swift-syntax 602
✓ Swift 6.1 × swift-syntax 603
✓ Swift 6.1 × swift-syntax 509
✓ Swift 6.1 × swift-syntax 604
✓ Swift 6.2 × swift-syntax 510
✓ Swift 6.2 × swift-syntax 600
✓ Swift 6.2 × swift-syntax 601
✓ Swift 6.2 × swift-syntax 602
✓ Swift 6.2 × swift-syntax 509
✓ Swift 6.2 × swift-syntax 603
✓ Swift 6.2 × swift-syntax 604

Results: 14 passed, 21 failed (of 35)
```

</details>

### After (trailing comma removed): 35 passed, 0 failed

| | 509 | 510 | 600 | 601 | 602 | 603 | 604 |
|---|---|---|---|---|---|---|---|
| **Swift 5.9** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **Swift 5.10** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **Swift 6.0** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **Swift 6.1** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
| **Swift 6.2** | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |

<details>
<summary>Full output (after fix)</summary>

```
$ bin/test-linux --parallel --continue-on-error --log-dir ./tmp
Auto-detected 6 parallel jobs (144 GB Podman VM)
Logging to: ./tmp/2026-03-29_190940
Running 35 combinations with 6 parallel jobs...
✓ Swift 5.9 × swift-syntax 603
✓ Swift 5.9 × swift-syntax 600
✓ Swift 5.9 × swift-syntax 601
✓ Swift 5.9 × swift-syntax 602
✓ Swift 5.9 × swift-syntax 510
✓ Swift 5.9 × swift-syntax 509
✓ Swift 5.10 × swift-syntax 600
✓ Swift 5.10 × swift-syntax 601
✓ Swift 5.10 × swift-syntax 510
✓ Swift 5.9 × swift-syntax 604
✓ Swift 5.10 × swift-syntax 602
✓ Swift 5.10 × swift-syntax 509
✓ Swift 5.10 × swift-syntax 603
✓ Swift 5.10 × swift-syntax 604
✓ Swift 6.0 × swift-syntax 510
✓ Swift 6.0 × swift-syntax 600
✓ Swift 6.0 × swift-syntax 601
✓ Swift 6.0 × swift-syntax 509
✓ Swift 6.0 × swift-syntax 602
✓ Swift 6.0 × swift-syntax 603
✓ Swift 6.1 × swift-syntax 510
✓ Swift 6.0 × swift-syntax 604
✓ Swift 6.1 × swift-syntax 600
✓ Swift 6.1 × swift-syntax 509
✓ Swift 6.1 × swift-syntax 601
✓ Swift 6.1 × swift-syntax 602
✓ Swift 6.1 × swift-syntax 603
✓ Swift 6.1 × swift-syntax 604
✓ Swift 6.2 × swift-syntax 600
✓ Swift 6.2 × swift-syntax 510
✓ Swift 6.2 × swift-syntax 601
✓ Swift 6.2 × swift-syntax 509
✓ Swift 6.2 × swift-syntax 602
✓ Swift 6.2 × swift-syntax 603
✓ Swift 6.2 × swift-syntax 604

Results: 35 passed, 0 failed (of 35)
```

</details>

### Reproduce locally

Requires [Podman](https://podman.io/) (`brew install podman`):

```bash
# Setup Podman VM (interactive, one-time)
bin/setup-podman

# Run the full matrix
bin/test-linux --parallel --continue-on-error

# Or test a specific combination
bin/test-linux --swift 5.9 --swift-syntax 509 --verbose
```

## Optional testing infrastructure (second commit)

The second commit adds `bin/test-linux`, `bin/setup-podman`, and a `SWIFT_SYNTAX_VERSION` env var mechanism to both Package manifests, enabling targeted testing of specific Swift × swift-syntax combinations. These scripts were extracted from [gohanlon/swift-memberwise-init-macro](https://github.com/gohanlon/swift-memberwise-init-macro), where they're used for the same kind of cross-version testing. This commit is optional — happy to drop it before merging if you'd prefer to keep things minimal.
