### PR TITLE
Fix color space issue for snapshot with drawHierarchyInKeyWindow set to true

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -110,7 +110,8 @@
     let pixelCount = oldCgImage.width * oldCgImage.height
     let byteCount = imageContextBytesPerPixel * pixelCount
     var oldBytes = [UInt8](repeating: 0, count: byteCount)
-    guard let oldData = context(for: oldCgImage, data: &oldBytes)?.data else {
+    guard let oldContext = context(for: oldCgImage, data: &oldBytes),
+          let oldData = oldContext.data else {
       return "Reference image's data could not be loaded."
     }
     if let newContext = context(for: newCgImage), let newData = newContext.data {
@@ -130,9 +131,12 @@
       return "Newly-taken snapshot does not match reference."
     }
     if perceptualPrecision < 1, #available(iOS 11.0, tvOS 11.0, *) {
+      guard let oldNormalized = oldContext.makeImage(),
+            let newNormalized = newerContext.makeImage()
+      else { return "Snapshot color space normalization failed." }
       return perceptuallyCompare(
-        CIImage(cgImage: oldCgImage),
-        CIImage(cgImage: newCgImage),
+        CIImage(cgImage: oldNormalized),
+        CIImage(cgImage: newNormalized),
         pixelPrecision: precision,
         perceptualPrecision: perceptualPrecision
       )


### PR DESCRIPTION
Use  CGImage with normalised color space for perceptual comparison.

Partially resolves  https://github.com/pointfreeco/swift-snapshot-testing/issues/1083
There is still issue when running tests with same env but on different GPU architecture (eg M2 Mac vs M4 Mac), yet this can be handled much easier with high value of perceptual precision as compared to current state.