### PR TITLE
Fix Swift 6.3 build failure in recordSwiftTestingAttachment (#1085)

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -1,12 +1,6 @@
 import Foundation
 import XCTest
 
-#if canImport(UIKit)
-  import UIKit
-#elseif canImport(AppKit)
-  import AppKit
-#endif
-
 #if canImport(Testing)
   import Testing
 #endif
@@ -640,16 +634,7 @@ enum File {
     sourceLocation: SourceLocation
   ) {
     #if !os(Android) && !os(Linux) && !os(Windows)
-      #if compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))
-        if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *),
-          name.hasSuffix(".png"),
-          let image = Image(data: data)
-        {
-          Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
-          return
-        }
-      #endif
-      Attachment.record(data, named: name, sourceLocation: sourceLocation)
+      Attachment.record(Array(data), named: name, sourceLocation: sourceLocation)
     #endif
   }
 #endif


### PR DESCRIPTION
## Summary

Fixes #1085. `swift build --build-tests` (and `swift test`) fails to link `SnapshotTesting` against the open-source `swift-6.3-RELEASE` toolchain:

```
AssertSnapshot.swift:648:11: error: generic struct 'Attachment' requires that '_AttachableImageWrapper<NSImage>' conform to 'Attachable'
AssertSnapshot.swift:648:22: error: static method 'record(_:named:as:sourceLocation:)' requires that '_AttachableImageWrapper<NSImage>' conform to 'AttachableWrapper'
AssertSnapshot.swift:648:22: error: static method 'record(_:named:as:sourceLocation:)' requires that 'NSImage' conform to 'AttachableAsImage'
AssertSnapshot.swift:652:7: error: generic struct 'Attachment' requires that 'Data' conform to 'Attachable'
```

`Data: Attachable` and `NSImage: AttachableAsImage` live in the cross-import overlays `_Testing_Foundation` and `_Testing_AppKit`. SwiftPM only passes `-enable-cross-import-overlays` to test targets ([source](https://github.com/swiftlang/swift-package-manager/blob/dda772607e25f062942f4537b125a2a4edd4f5dc/Sources/Build/BuildDescription/SwiftModuleBuildDescription.swift#L1150)), so the `SnapshotTesting` library target can't see those conformances. Issue #1085 has the full diagnosis.

## Fix

Switch `recordSwiftTestingAttachment` to `Attachment.record(Array(data), ...)`. `Array<UInt8>: Attachable` ships in the main `Testing` module — no cross-import overlay required — so it builds on both 6.2 and 6.3.

The `Image(data:)` PNG-preview branch is removed: Swift Testing already promotes raw byte attachments to image previews based on the filename suffix, so the explicit `compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))` upgrade was redundant. Dropping it also lets us remove the top-level `import UIKit` / `import AppKit` in this file — the remaining `UIImage` cast on the iOS/tvOS path is satisfied by `import XCTest`'s transitive UIKit re-export.

## Verification

On Swift 6.3.1 (open-source `swift-6.3.1-RELEASE`):

- \`swift build --build-tests\` ✅ links cleanly (failed before)
- \`swift test\` ✅ all suites build and run; no regressions attributable to this change
- \`xcodebuild -scheme SnapshotTesting -destination 'generic/platform=iOS Simulator' build\` ✅

I also ran a standalone verification that the new \`Attachment.record(Array(data), named:)\` API behaves as expected (byte fidelity, PNG/JPEG attachments via AppKit and UIKit, empty data, 1 MB data) on both Swift 6.2.4 and 6.3.0.

## Test plan

- [x] \`swift build --build-tests\` on Swift 6.3.1 (open-source)
- [x] \`swift test\` on Swift 6.3.1 (open-source)
- [x] \`xcodebuild build\` for iOS Simulator
- [ ] CI on full matrix (Linux/macOS, Swift 6.0–6.3)