### PR TITLE
Update checkout actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: macOS
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
@@ -34,7 +34,7 @@ jobs:
     name: Linux (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: swift test
 
   android:
@@ -45,7 +45,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: skiptools/swift-android-action@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -14,7 +14,7 @@ jobs:
     name: swift-format
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Xcode Select
         run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
       - name: Install


### PR DESCRIPTION
## Summary
- update all workflow uses of `actions/checkout` to `v6`
- include both the main CI workflow and the format workflow so checkout stays consistent across repository automation

## Validation
- verified the current `actions/checkout` release is `v6.0.2`
- ran `git diff --check`
- verified `.github/workflows` no longer references older checkout majors

Note: I could not run SwiftPM or Xcode tests on this Windows host because Swift/Xcode is not installed locally.