### PR TITLE
Feature: Extending init for artifact directory to support writing to another folder

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -537,8 +537,11 @@ public func verifySnapshot<Value, Format>(
       }
 
       if record == .failed {
-        try recordSnapshot(writeToDisk: true)
-        failureMessage += " A new snapshot was automatically recorded."
+        let shouldWriteToDisk = artifactsDirectory == nil
+        try recordSnapshot(writeToDisk: shouldWriteToDisk)
+        if shouldWriteToDisk {
+          failureMessage += " A new snapshot was automatically recorded."
+        }
       }
 
       return """

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -440,15 +440,22 @@ public func verifySnapshot<Value, Format>(
             No reference was found on disk. New snapshot was not recorded because recording is disabled
             """
         } else {
-          try recordSnapshot(writeToDisk: true)
+          let shouldWriteToDisk = artifactsDirectory == nil
+          try recordSnapshot(writeToDisk: shouldWriteToDisk)
 
-          return """
-            No reference was found on disk. Automatically recorded snapshot: …
+          if shouldWriteToDisk {
+            return """
+              No reference was found on disk. Automatically recorded snapshot: …
 
-            open "\(snapshotFileUrl.absoluteString)"
+              open "\(snapshotFileUrl.absoluteString)"
 
-            Re-run "\(testName)" to assert against the newly-recorded snapshot.
-            """
+              Re-run "\(testName)" to assert against the newly-recorded snapshot.
+              """
+          } else {
+            return """
+              No reference was found on disk. Snapshot was not recorded because an artifacts directory is configured.
+              """
+          }
         }
       }
 

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -112,6 +112,7 @@ public func assertSnapshot<Value, Format>(
   as snapshotting: Snapshotting<Value, Format>,
   named name: String? = nil,
   record: SnapshotTestingConfiguration.Record? = nil,
+  artifactsDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
   file filePath: StaticString = #filePath,
@@ -124,6 +125,7 @@ public func assertSnapshot<Value, Format>(
     as: snapshotting,
     named: name,
     record: record,
+    artifactsDirectory: artifactsDirectory,
     timeout: timeout,
     fileID: fileID,
     file: filePath,
@@ -286,6 +288,7 @@ public func verifySnapshot<Value, Format>(
   named name: String? = nil,
   record: SnapshotTestingConfiguration.Record? = nil,
   snapshotDirectory: String? = nil,
+  artifactsDirectory: String? = nil,
   timeout: TimeInterval = 5,
   fileID: StaticString = #fileID,
   file filePath: StaticString = #file,
@@ -467,7 +470,8 @@ public func verifySnapshot<Value, Format>(
       }
 
       let artifactsUrl = URL(
-        fileURLWithPath: ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"]
+        fileURLWithPath: artifactsDirectory
+          ?? ProcessInfo.processInfo.environment["SNAPSHOT_ARTIFACTS"]
           ?? NSTemporaryDirectory(),
         isDirectory: true
       )


### PR DESCRIPTION
# This PR fixes one of the most critical problems for the CI pipelines. 

## Background:
ProcessInfo.processInfo.environment is not supported for multiple test targets by xctestplan, therefore, one can't propagate the EVN variable from the xctestplan to redirect the snapshots folder. 

## Usage:
By passing in the directory, the failed snapshots will be recorded into a different folder, therefore, repetition mode will no longer let the test succeed. As of now, when repetition mode is on, the first test fails and regenerates the snapshots, second try will load the regenerated snapshot and let the test pass. With recording the failed snapshots to a different folder will allow you to repeat the snapshots and they will be always reading the original snapshot. 

Furthermore, the folder with failed snapshots can then be used as an upload source of truth of the failing snapshots. Via scripting you can then replace the failing snapshots downloaded from the CI workflow locally to double check the changes and push it back. 
