### PR TITLE
fix: avoid safe area influence for `UIHostingController`s

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -73,7 +73,6 @@
           } else {
             let hostingController = UIHostingController.init(rootView: view)
 
-            // NB: Avoid safe area influence.
             if config.safeArea == .zero {
               if #available(iOS 16.4, tvOS 16.4, *) {
                 hostingController.safeAreaRegions = []

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -73,6 +73,15 @@
           } else {
             let hostingController = UIHostingController.init(rootView: view)
 
+            // NB: Avoid safe area influence.
+            if config.safeArea == .zero {
+              if #available(iOS 16.4, tvOS 16.4, *) {
+                hostingController.safeAreaRegions = []
+              } else {
+                hostingController._disableSafeArea = true
+              }
+            }
+
             let maxSize = CGSize(width: 0.0, height: 0.0)
             config.size = hostingController.sizeThatFits(in: maxSize)
 


### PR DESCRIPTION
This fixes an issue where if a view was bigger than the key window, it would get a footer added for the safe area.

Using `ignoresSafeArea()` on the view under test did not fix the problem, however, I worked out that this does.

Would really appreciate a review here - it is a huge pain point for us.

If the condition I've added it under isn't to your liking, I could add a separate configuration perhaps?

Example reproducer:
```swift
@MainActor
struct SnapshotReproducerTests {
  @Test(arguments: [
    50, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, 1000
  ])
  func example(size: CGFloat) async throws {
    let view = Color.pink.frame(width: size, height: size)

    assertSnapshot(
      of: view,
      as: .image(
        drawHierarchyInKeyWindow: true,
      ),
      record: .all,
      testName: "\(#function)-\(Int(size))"
    )
  }
}
```