### PR TITLE
Preserve the content type of failure diff attachments

### DIFF
--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -7,6 +7,10 @@ import XCTest
   import AppKit
 #endif
 
+#if canImport(UniformTypeIdentifiers)
+  import UniformTypeIdentifiers
+#endif
+
 #if canImport(Testing)
   import Testing
 #endif
@@ -508,10 +512,14 @@ public func verifySnapshot<Value, Format>(
                   case .xcTest(let attachment):
                     activity.add(attachment)
                   case .data(let data, let name):
-                    let attachment = XCTAttachment(data: data)
+                    let attachment: XCTAttachment
+                    if let identifier = uniformTypeIdentifier(forFileName: name) {
+                      attachment = XCTAttachment(data: data, uniformTypeIdentifier: identifier)
+                    } else {
+                      attachment = XCTAttachment(data: data)
+                    }
                     attachment.name = name
                     activity.add(attachment)
-                    break
                   }
                 }
               }
@@ -551,6 +559,17 @@ public func verifySnapshot<Value, Format>(
 }
 
 // MARK: - Private
+
+private func uniformTypeIdentifier(forFileName fileName: String) -> String? {
+  let pathExtension = (fileName as NSString).pathExtension
+  guard !pathExtension.isEmpty else { return nil }
+  #if canImport(UniformTypeIdentifiers)
+    if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+      return UTType(filenameExtension: pathExtension)?.identifier
+    }
+  #endif
+  return nil
+}
 
 private var counter: File.Counter {
   #if canImport(Testing)


### PR DESCRIPTION
Fixes #1107

## Summary

Since the `DiffAttachment` refactor, failure diff artifacts are attached to XCTest results via `XCTAttachment(data:)`, which defaults the payload type to `application/octet-stream`. Tools that consume `.xcresult` bundles (e.g. [XCTestHTMLReport](https://github.com/XCTestHTMLReport/XCTestHTMLReport)) only render attachments whose type is `image/*`, so the reference/failure/difference images no longer show up in HTML reports — the attachments are listed, but no picture is displayed.

## Fix

Derive the uniform type identifier from the artifact's file name (`reference.png`, `failure.png`, `difference.png`, `difference.patch`, …) and pass it to `XCTAttachment(data:uniformTypeIdentifier:)`, falling back to the previous behavior when the type cannot be resolved.

- `UniformTypeIdentifiers` is imported behind `#if canImport(...)` and used behind an `#available` check, matching the package's minimum deployment targets (iOS 13 / macOS 10.15 / tvOS 13 / watchOS 6).
- The swift-testing path is unaffected: `recordSwiftTestingAttachment` already preserves the file-name extension.

## Verification

Exported attachments from an `.xcresult` produced with this change: `xcrun xcresulttool export attachments` now exports the image diffs as `.png` (previously exported as untyped data).