### PR TITLE
Prevent image diff crashes across pixel formats

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -179,7 +179,7 @@
 
   private func diff(_ old: UIImage, _ new: UIImage) -> UIImage {
     normalizedComponentDiff(old, new)
-    ?? blendModeDiff(old, new)
+      ?? blendModeDiff(old, new)
   }
 
   private func blendModeDiff(_ old: UIImage, _ new: UIImage) -> UIImage {
@@ -194,96 +194,100 @@
     return differenceImage
   }
 
-private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage? {
-  guard let oldCgImage = old.cgImage,
-        let pngData = new.pngData(),
-        let newCgImage = UIImage(data: pngData)?.cgImage,
-        oldCgImage.width == newCgImage.width,
-        oldCgImage.height == newCgImage.height,
-        let oldData = oldCgImage.dataProvider?.data,
-        let newData = newCgImage.dataProvider?.data
-  else {
-    return nil
-  }
-  
-  guard let outputColorSpace = CGColorSpace(name: CGColorSpace.linearGray),
-        let outputFormat = vImage_CGImageFormat(
-          bitsPerComponent: imageContextBitsPerComponent,
-          bitsPerPixel: imageContextBitsPerComponent,
-          colorSpace: outputColorSpace,
-          bitmapInfo: .init()
-        )
-  else {
-    return nil
-  }
-  
-  let width = oldCgImage.width
-  let height = oldCgImage.height
-  let pixelCount = width * height
-  let scale = old.scale
-  
-  let oldBytes = CFDataGetBytePtr(oldData)!
-  let newBytes = CFDataGetBytePtr(newData)!
-  var diffBytes = [UInt8](repeating: 0, count: pixelCount)
-  
-  var index = 0
-  while index < pixelCount {
-    defer { index += 1 }
-    let pixelOffset = index * imageContextBytesPerPixel
-    
-    let rOld = Int16(oldBytes[pixelOffset])
-    let gOld = Int16(oldBytes[pixelOffset + 1])
-    let bOld = Int16(oldBytes[pixelOffset + 2])
-    let aOld = Int16(oldBytes[pixelOffset + 3])
-    
-    let rNew = Int16(newBytes[pixelOffset])
-    let gNew = Int16(newBytes[pixelOffset + 1])
-    let bNew = Int16(newBytes[pixelOffset + 2])
-    let aNew = Int16(newBytes[pixelOffset + 3])
-    
-    let rDiff = abs(rOld - rNew)
-    let gDiff = abs(gOld - gNew)
-    let bDiff = abs(bOld - bNew)
-    let aDiff = abs(aOld - aNew)
-    
-    let maxDiff = max(rDiff, gDiff, bDiff, aDiff)
-    diffBytes[index] = UInt8(maxDiff)
-  }
-  
-  let outputCgImage: CGImage? = diffBytes.withUnsafeMutableBytes { diffPtr in
-    var diffBuffer = vImage_Buffer(
-      data: diffPtr.baseAddress,
-      height: vImagePixelCount(height),
-      width: vImagePixelCount(width),
-      rowBytes: width
-    )
-    
-    do {
-      var normalizedBuffer = try vImage_Buffer(
-        width: width,
-        height: height,
-        bitsPerPixel: UInt32(imageContextBitsPerComponent)
-      )
-      defer { normalizedBuffer.free() }
-      
-      let error = vImageContrastStretch_Planar8(
-        &diffBuffer,
-        &normalizedBuffer,
-        vImage_Flags(kvImageNoFlags)
-      )
-      
-      let buffer = error == kvImageNoError ? normalizedBuffer : diffBuffer
-      
-      return try buffer.createCGImage(format: outputFormat)
-    } catch {
+  private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage? {
+    guard let oldCgImage = old.cgImage,
+      let pngData = new.pngData(),
+      let newCgImage = UIImage(data: pngData)?.cgImage,
+      oldCgImage.width == newCgImage.width,
+      oldCgImage.height == newCgImage.height
+    else {
       return nil
     }
+
+    guard let outputColorSpace = CGColorSpace(name: CGColorSpace.linearGray),
+      let outputFormat = vImage_CGImageFormat(
+        bitsPerComponent: imageContextBitsPerComponent,
+        bitsPerPixel: imageContextBitsPerComponent,
+        colorSpace: outputColorSpace,
+        bitmapInfo: .init()
+      )
+    else {
+      return nil
+    }
+
+    let width = oldCgImage.width
+    let height = oldCgImage.height
+    let pixelCount = width * height
+    let byteCount = pixelCount * imageContextBytesPerPixel
+    let scale = old.scale
+
+    var oldBytes = [UInt8](repeating: 0, count: byteCount)
+    var newBytes = [UInt8](repeating: 0, count: byteCount)
+    guard context(for: oldCgImage, data: &oldBytes) != nil,
+      context(for: newCgImage, data: &newBytes) != nil
+    else {
+      return nil
+    }
+    var diffBytes = [UInt8](repeating: 0, count: pixelCount)
+
+    var index = 0
+    while index < pixelCount {
+      defer { index += 1 }
+      let pixelOffset = index * imageContextBytesPerPixel
+
+      let rOld = Int16(oldBytes[pixelOffset])
+      let gOld = Int16(oldBytes[pixelOffset + 1])
+      let bOld = Int16(oldBytes[pixelOffset + 2])
+      let aOld = Int16(oldBytes[pixelOffset + 3])
+
+      let rNew = Int16(newBytes[pixelOffset])
+      let gNew = Int16(newBytes[pixelOffset + 1])
+      let bNew = Int16(newBytes[pixelOffset + 2])
+      let aNew = Int16(newBytes[pixelOffset + 3])
+
+      let rDiff = abs(rOld - rNew)
+      let gDiff = abs(gOld - gNew)
+      let bDiff = abs(bOld - bNew)
+      let aDiff = abs(aOld - aNew)
+
+      let maxDiff = max(rDiff, gDiff, bDiff, aDiff)
+      diffBytes[index] = UInt8(maxDiff)
+    }
+
+    let outputCgImage: CGImage? = diffBytes.withUnsafeMutableBytes { diffPtr in
+      var diffBuffer = vImage_Buffer(
+        data: diffPtr.baseAddress,
+        height: vImagePixelCount(height),
+        width: vImagePixelCount(width),
+        rowBytes: width
+      )
+
+      do {
+        var normalizedBuffer = try vImage_Buffer(
+          width: width,
+          height: height,
+          bitsPerPixel: UInt32(imageContextBitsPerComponent)
+        )
+        defer { normalizedBuffer.free() }
+
+        let error = vImageContrastStretch_Planar8(
+          &diffBuffer,
+          &normalizedBuffer,
+          vImage_Flags(kvImageNoFlags)
+        )
+
+        let buffer = error == kvImageNoError ? normalizedBuffer : diffBuffer
+
+        return try buffer.createCGImage(format: outputFormat)
+      } catch {
+        return nil
+      }
+    }
+
+    guard let outputCgImage else { return nil }
+
+    return UIImage(cgImage: outputCgImage, scale: scale, orientation: .up)
   }
-  
-  guard let outputCgImage else { return nil }
-  
-  return UIImage(cgImage: outputCgImage, scale: scale, orientation: .up)
-}
 #endif
 
 #if os(iOS) || os(tvOS) || os(macOS)

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -276,26 +276,9 @@ final class SnapshotTestingTests: BaseTestCase {
       let width = 256
       let height = 256
       let colorSpace = try XCTUnwrap(CGColorSpace(name: CGColorSpace.sRGB))
-      let referenceData = Data(repeating: 255, count: width * height * 3)
+      let referenceData = Data(repeating: 255, count: width * height * 4)
       let referenceProvider = try XCTUnwrap(CGDataProvider(data: referenceData as CFData))
       let referenceCgImage = try XCTUnwrap(
-        CGImage(
-          width: width,
-          height: height,
-          bitsPerComponent: 8,
-          bitsPerPixel: 24,
-          bytesPerRow: width * 3,
-          space: colorSpace,
-          bitmapInfo: [],
-          provider: referenceProvider,
-          decode: nil,
-          shouldInterpolate: false,
-          intent: .defaultIntent
-        )
-      )
-      let failureData = Data(repeating: 0, count: width * height * 4)
-      let failureProvider = try XCTUnwrap(CGDataProvider(data: failureData as CFData))
-      let failureCgImage = try XCTUnwrap(
         CGImage(
           width: width,
           height: height,
@@ -304,12 +287,32 @@ final class SnapshotTestingTests: BaseTestCase {
           bytesPerRow: width * 4,
           space: colorSpace,
           bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+          provider: referenceProvider,
+          decode: nil,
+          shouldInterpolate: false,
+          intent: .defaultIntent
+        )
+      )
+      let failureData = Data(repeating: 0, count: width * height * 2)
+      let failureProvider = try XCTUnwrap(CGDataProvider(data: failureData as CFData))
+      let failureCgImage = try XCTUnwrap(
+        CGImage(
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bitsPerPixel: 16,
+          bytesPerRow: width * 2,
+          space: CGColorSpaceCreateDeviceGray(),
+          bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
           provider: failureProvider,
           decode: nil,
           shouldInterpolate: false,
           intent: .defaultIntent
         )
       )
+
+      XCTAssertEqual(referenceCgImage.bitsPerPixel, 32)
+      XCTAssertEqual(failureCgImage.bitsPerPixel, 16)
 
       let difference = Diffing<UIImage>.image.diffV2(
         UIImage(cgImage: referenceCgImage),

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -271,6 +271,56 @@ final class SnapshotTestingTests: BaseTestCase {
     #endif
   }
 
+  func testImageDiffWithDifferentPixelFormats() throws {
+    #if os(iOS) || os(tvOS)
+      let width = 256
+      let height = 256
+      let colorSpace = try XCTUnwrap(CGColorSpace(name: CGColorSpace.sRGB))
+      let referenceData = Data(repeating: 255, count: width * height * 3)
+      let referenceProvider = try XCTUnwrap(CGDataProvider(data: referenceData as CFData))
+      let referenceCgImage = try XCTUnwrap(
+        CGImage(
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bitsPerPixel: 24,
+          bytesPerRow: width * 3,
+          space: colorSpace,
+          bitmapInfo: [],
+          provider: referenceProvider,
+          decode: nil,
+          shouldInterpolate: false,
+          intent: .defaultIntent
+        )
+      )
+      let failureData = Data(repeating: 0, count: width * height * 4)
+      let failureProvider = try XCTUnwrap(CGDataProvider(data: failureData as CFData))
+      let failureCgImage = try XCTUnwrap(
+        CGImage(
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bitsPerPixel: 32,
+          bytesPerRow: width * 4,
+          space: colorSpace,
+          bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+          provider: failureProvider,
+          decode: nil,
+          shouldInterpolate: false,
+          intent: .defaultIntent
+        )
+      )
+
+      let difference = Diffing<UIImage>.image.diffV2(
+        UIImage(cgImage: referenceCgImage),
+        UIImage(cgImage: failureCgImage)
+      )
+
+      XCTAssertEqual(difference?.0, "Newly-taken snapshot does not match reference.")
+      XCTAssertEqual(difference?.1.count, 3)
+    #endif
+  }
+
   func testSCNView() {
     // #if os(iOS) || os(macOS) || os(tvOS)
     // // NB: CircleCI crashes while trying to instantiate SCNView.


### PR DESCRIPTION
## What

Normalize both images into the same 8-bit RGBA bitmap format before calculating the component diff, and add a regression test that compares images backed by 24-bit RGB and 32-bit RGBA data.

## Why

Generating a diff image for a failed snapshot comparison should report the mismatch and its attachments. It should not crash the test process when the reference and failure images use different underlying pixel formats.

## Root cause

`normalizedComponentDiff` read bytes directly from each `CGImage` data provider while indexing both buffers as tightly packed four-byte RGBA pixels. Core Graphics does not guarantee that provider data uses that pixel format or row layout, so a three-byte RGB buffer could be read past its end.

The updated implementation draws both images through the existing known-format bitmap context and performs the diff on those normalized buffers.

## Impact

Snapshot mismatches whose images decode to different pixel formats now produce the normal reference, failure, and difference attachments instead of risking `EXC_BAD_ACCESS` during failure reporting.

## Checks

- Xcode 26.5, iOS 26.5 simulator:
  `xcodebuild test -scheme swift-snapshot-testing-Package -destination 'platform=iOS Simulator,id=3BC2ABB5-651E-429E-8983-8CDBEC035388' -only-testing:SnapshotTestingTests/SnapshotTestingTests/testImageDiffWithDifferentPixelFormats`
- Result: 1 test passed, 0 failures.
- `git diff --check`

Fixes #1097
