### PR TITLE
refactor: skip the deprecated middle man

### DIFF
--- a/Sources/SnapshotTesting/Internal/Deprecations.swift
+++ b/Sources/SnapshotTesting/Internal/Deprecations.swift
@@ -553,7 +553,12 @@ public func verifySnapshot<Value, Format>(
 @available(*, deprecated, renamed: "XCTestCase")
 public typealias SnapshotTestCase = XCTestCase
 
-@available(*, deprecated, renamed: "isRecording")
+@available(
+  *,
+   deprecated,
+   message:
+    "Use 'withSnapshotTesting' to customize the record mode. See the documentation for more information."
+)
 public var record: Bool {
   get { isRecording }
   set { isRecording = newValue }


### PR DESCRIPTION
The deprecated `record` property had an auto-fixing deprecation message that pointed users to **another** deprecated property, which was not the intended migration path. (IMO)

This change updates the deprecation message to guide users directly toward the recommended `withSnapshotTesting` API.

The implementation remains untouched to preserve a single source of truth and avoid duplicating the fallback logic.