### PR TITLE
Fix OSS toolchain builds.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,25 @@ jobs:
       - name: Run tests
         run: make test-swift
 
+  macos-swiftly:
+    strategy:
+      matrix:
+        swift:
+          - '6.3.1'
+
+    name: macOS (Swiftly ${{ matrix.swift }})
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Swift ${{ matrix.swift }}
+        uses: swift-actions/setup-swift@v3
+        with:
+          swift-version: ${{ matrix.swift }}
+      - name: Print Swift version
+        run: swift --version
+      - name: Build
+        run: swift build --build-tests
+
   ubuntu:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         swift:
-          - "6.2"
+          - "6.3"
     name: Android
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ fastlane/screenshots
 fastlane/test_output
 
 .DS_Store
+.swift-version

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v16),
-    .macOS(.v13),
-    .tvOS(.v16),
-    .watchOS(.v9),
+    .iOS(.v15),
+    .macOS(.v12),
+    .tvOS(.v15),
+    .watchOS(.v8),
   ],
   products: [
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13),
-    .watchOS(.v6),
+    .iOS(.v17),
+    .macOS(.v14),
+    .tvOS(.v17),
+    .watchOS(.v10),
   ],
   products: [
     .library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v17),
-    .macOS(.v14),
-    .tvOS(.v17),
-    .watchOS(.v10),
+    .iOS(.v16),
+    .macOS(.v13),
+    .tvOS(.v16),
+    .watchOS(.v9),
   ],
   products: [
     .library(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v16),
-    .macOS(.v13),
-    .tvOS(.v16),
-    .watchOS(.v9),
+    .iOS(.v15),
+    .macOS(.v12),
+    .tvOS(.v15),
+    .watchOS(.v8),
   ],
   products: [
     .library(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v13),
-    .macOS(.v10_15),
-    .tvOS(.v13),
-    .watchOS(.v6),
+    .iOS(.v17),
+    .macOS(.v14),
+    .tvOS(.v17),
+    .watchOS(.v10),
   ],
   products: [
     .library(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -5,10 +5,10 @@ import PackageDescription
 let package = Package(
   name: "swift-snapshot-testing",
   platforms: [
-    .iOS(.v17),
-    .macOS(.v14),
-    .tvOS(.v17),
-    .watchOS(.v10),
+    .iOS(.v16),
+    .macOS(.v13),
+    .tvOS(.v16),
+    .watchOS(.v9),
   ],
   products: [
     .library(

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -11,9 +11,6 @@ import XCTest
   import Testing
 #endif
 
-#if canImport(_Testing_Foundation)
-  import _Testing_Foundation
-#endif
 #if canImport(UIKit) && canImport(_Testing_UIKit)
   import _Testing_UIKit
 #elseif canImport(AppKit) && canImport(_Testing_AppKit)
@@ -643,15 +640,12 @@ enum File {
   ) {
     #if !os(Android) && !os(Linux) && !os(Windows)
       #if compiler(>=6.3) && (canImport(UIKit) || canImport(AppKit))
-        if #available(iOS 14.0, tvOS 14.0, macOS 11.0, *),
-          name.hasSuffix(".png"),
-          let image = Image(data: data)
-        {
+        if name.hasSuffix(".png"), let image = Image(data: data) {
           Attachment.record(image, named: name, as: .png, sourceLocation: sourceLocation)
           return
         }
       #endif
-      Attachment.record(data, named: name, sourceLocation: sourceLocation)
+      Attachment.record([UInt8](data), named: name, sourceLocation: sourceLocation)
     #endif
   }
 #endif

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -11,6 +11,15 @@ import XCTest
   import Testing
 #endif
 
+#if canImport(_Testing_Foundation)
+  import _Testing_Foundation
+#endif
+#if canImport(UIKit) && canImport(_Testing_UIKit)
+  import _Testing_UIKit
+#elseif canImport(AppKit) && canImport(_Testing_AppKit)
+  import _Testing_AppKit
+#endif
+
 /// Enhances failure messages with a command line diff tool expression that can be copied and pasted
 /// into a terminal.
 @available(
@@ -574,17 +583,10 @@ func sanitizePathComponent(_ string: String) -> String {
 }
 
 #if !os(Android) && !os(Linux) && !os(Windows)
-  import CoreServices
+  import UniformTypeIdentifiers
 
   func uniformTypeIdentifier(fromExtension pathExtension: String) -> String? {
-    // This can be much cleaner in macOS 11+ using UTType
-    let unmanagedString = UTTypeCreatePreferredIdentifierForTag(
-      kUTTagClassFilenameExtension as CFString,
-      pathExtension as CFString,
-      nil
-    )
-
-    return unmanagedString?.takeRetainedValue() as String?
+    UTType(filenameExtension: pathExtension)?.identifier
   }
 #endif
 

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -59,14 +59,14 @@
       let namesByType: [NSBezierPath.ElementType: String] = [
         .moveTo: "MoveTo",
         .lineTo: "LineTo",
-        .cubicCurveTo: "CurveTo",
+        .curveTo: "CurveTo",
         .closePath: "Close",
       ]
 
       let numberOfPointsByType: [NSBezierPath.ElementType: Int] = [
         .moveTo: 1,
         .lineTo: 1,
-        .cubicCurveTo: 3,
+        .curveTo: 3,
         .closePath: 0,
       ]
 

--- a/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSBezierPath.swift
@@ -59,14 +59,14 @@
       let namesByType: [NSBezierPath.ElementType: String] = [
         .moveTo: "MoveTo",
         .lineTo: "LineTo",
-        .curveTo: "CurveTo",
+        .cubicCurveTo: "CurveTo",
         .closePath: "Close",
       ]
 
       let numberOfPointsByType: [NSBezierPath.ElementType: Int] = [
         .moveTo: 1,
         .lineTo: 1,
-        .curveTo: 3,
+        .cubicCurveTo: 3,
         .closePath: 0,
       ]
 


### PR DESCRIPTION
Fixes #1085

Currently SnapshotTesting doesn't build with OSS toolchains because cross-import overlays for Foundation, UIKit and AppKit are not automatically provided, and so the various `Attachable` conformances are not found. We can manually import these overlays as a very easy fix, but the overlays are only available on newer deployment targets. Up for discussion of whether or not we want to bump deployment targets (we still support over 3 years of platforms).