### PR TITLE
fix: repair the Android CI job and clear the checkout deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     name: macOS
     runs-on: macos-15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Run tests
@@ -34,7 +34,7 @@ jobs:
     name: Linux (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: swift test
 
   android:
@@ -45,7 +45,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: skiptools/swift-android-action@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,6 @@ jobs:
         with:
           swift-version: ${{ matrix.swift }}
           copy-files: ${GITHUB_WORKSPACE}/Tests/SnapshotTestingTests/__Snapshots__
+          # AssertSnapshot.swift hardcodes this path for os(Android); the
+          # action's default changed to swift-android-tests in v2.9.5.
+          android-emulator-test-folder: /data/local/tmp/android-xctest


### PR DESCRIPTION
Hi,

I would like to contribute a CI fix.

**Commit 1 — pin the Android emulator test folder.**
`AssertSnapshot.swift` resolves snapshot directories on Android from the hardcoded
`/data/local/tmp/android-xctest` path, but `skiptools/swift-android-action` changed its default
test folder to `swift-android-tests` in v2.9.5, so the job no longer finds any reference
snapshots. Pinning `android-emulator-test-folder` back to the path the library expects fixes it —
validated on a fork, where the Android job is green with this exact pin.

**Commit 2 — bump `actions/checkout` v4 → v7.**
GitHub annotates every run with "Node.js 20 is deprecated. The following actions target Node.js 20
but are being forced to run on Node.js 24: actions/checkout@v4". v7 targets a current Node runtime
and removes the warning from all three jobs.

No source, test, or trigger changes — `ci.yml` only. This PR's own CI run demonstrates the fix.