### PR TITLE
fix: revive the CI Format workflow, dead on the retired macos-13 runner

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,19 +9,22 @@ concurrency:
   group: format-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   swift_format:
     name: swift-format
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Xcode Select
-        run: sudo xcode-select -s /Applications/Xcode_14.3.1.app
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app
       - name: Install
         run: brew install swift-format
       - name: Format
         run: make format
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Run swift-format
           branch: 'main'


### PR DESCRIPTION
Hi,

I would like to contribute another CI fix.

Every Format run since at least March has ended "cancelled" without executing a single step
([example](https://github.com/pointfreeco/swift-snapshot-testing/actions/runs/30285844107)): the
workflow requests the `macos-13` runner image, which GitHub has retired, so the job queues until
it is abandoned. The `swift-format` bot has effectively been offline since.

One commit, `format.yml` only:

- `runs-on: macos-13` → `macos-15`, with Xcode 16.4 to match what the CI workflow already uses
  (the previous Xcode 14.3.1 does not exist on current images).
- `actions/checkout` v3 → v7 and `git-auto-commit-action` v4 → v7 — both old versions target
  retired Node runtimes (GitHub now warns even on Node 20 actions).
- `permissions: contents: write`, which the auto-commit push needs when default workflow
  permissions are read-only.

Trigger (`main` pushes only) and the auto-commit target branch are unchanged.

Note: because the workflow pushes formatting commits to `main`, you may want to double-check the
result of the first run after merge.