### PR TITLE
Support visionOS behind compiler directives

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,7 @@ let package = Package(
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),
+    .visionOS(.v1),
   ],
   products: [
     .library(

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -9,6 +9,7 @@ let package = Package(
     .macOS(.v10_15),
     .tvOS(.v13),
     .watchOS(.v6),
+    .visionOS(.v1),
   ],
   products: [
     .library(

--- a/Sources/SnapshotTesting/AssertSnapshot.swift
+++ b/Sources/SnapshotTesting/AssertSnapshot.swift
@@ -452,7 +452,7 @@ public func verifySnapshot<Value, Format>(
       let data = try Data(contentsOf: snapshotFileUrl)
       let reference = snapshotting.diffing.fromData(data)
 
-      #if os(iOS) || os(tvOS)
+      #if os(iOS) || os(tvOS) || os(visionOS)
         // If the image generation fails for the diffable part and the reference was empty, use the reference
         if let localDiff = diffable as? UIImage,
           let refImage = reference as? UIImage,

--- a/Sources/SnapshotTesting/Common/Internal.swift
+++ b/Sources/SnapshotTesting/Common/Internal.swift
@@ -3,7 +3,7 @@
   typealias Image = NSImage
   typealias ImageView = NSImageView
   typealias View = NSView
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
   typealias Image = UIImage
   typealias ImageView = UIImageView

--- a/Sources/SnapshotTesting/Common/View.swift
+++ b/Sources/SnapshotTesting/Common/View.swift
@@ -1,17 +1,17 @@
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
   #if os(macOS)
     import Cocoa
   #endif
   import SceneKit
   import SpriteKit
-  #if os(iOS) || os(tvOS)
+  #if os(iOS) || os(tvOS) || os(visionOS)
     import UIKit
   #endif
   #if os(iOS) || os(macOS)
     import WebKit
   #endif
 
-  #if os(iOS) || os(tvOS)
+  #if os(iOS) || os(tvOS) || os(visionOS)
     public struct ViewImageConfig: Sendable {
       public enum Orientation {
         case landscape
@@ -819,7 +819,7 @@
               imageView.frame = view.frame
               #if os(macOS)
                 view.superview?.addSubview(imageView, positioned: .above, relativeTo: view)
-              #elseif os(iOS) || os(tvOS)
+              #elseif os(iOS) || os(tvOS) || os(visionOS)
                 view.superview?.insertSubview(imageView, aboveSubview: view)
               #endif
               callback(imageView)
@@ -850,7 +850,7 @@
           let cgImage = inWindow { skView.texture(from: skView.scene!)!.cgImage() }
           #if os(macOS)
             let image = Image(cgImage: cgImage, size: skView.bounds.size)
-          #elseif os(iOS) || os(tvOS)
+          #elseif os(iOS) || os(tvOS) || os(visionOS)
             let image = Image(cgImage: cgImage)
           #endif
           return Async(value: image)
@@ -903,7 +903,7 @@
       #endif
       return nil
     }
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
       func asImage() -> Image {
         let renderer = UIGraphicsImageRenderer(bounds: bounds)
         return renderer.image { rendererContext in
@@ -913,7 +913,7 @@
     #endif
   }
 
-  #if os(iOS) || os(tvOS)
+  #if os(iOS) || os(tvOS) || os(visionOS)
     extension UIApplication {
       static var sharedIfAvailable: UIApplication? {
         let sharedSelector = NSSelectorFromString("sharedApplication")
@@ -1076,11 +1076,26 @@
 
     private func getKeyWindow() -> UIWindow? {
       var window: UIWindow?
-      if #available(iOS 13.0, *) {
-        window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
-      } else {
-        window = UIApplication.sharedIfAvailable?.keyWindow
-      }
+      #if os(visionOS)
+        // 'UIApplication.windows' is deprecated on visionOS and documented to be empty
+        // for scene-based apps, so resolve the key window through the connected scenes
+        // and only fall back to the flat list.
+        let windowScenes =
+          UIApplication.sharedIfAvailable?.connectedScenes.compactMap { $0 as? UIWindowScene }
+          ?? []
+        window =
+          windowScenes.compactMap(\.keyWindow).first
+          ?? windowScenes.flatMap(\.windows).first { $0.isKeyWindow }
+          ?? UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
+      #else
+        if #available(iOS 13.0, *) {
+          window = UIApplication.sharedIfAvailable?.windows.first { $0.isKeyWindow }
+        } else {
+          // 'keyWindow' is marked unavailable in visionOS, so this deprecated
+          // fallback can only be compiled on the other platforms.
+          window = UIApplication.sharedIfAvailable?.keyWindow
+        }
+      #endif
       return window
     }
 

--- a/Sources/SnapshotTesting/Snapshotting/CALayer.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CALayer.swift
@@ -40,7 +40,7 @@
       }
     }
   }
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Snapshotting where Value == CALayer, Format == UIImage {

--- a/Sources/SnapshotTesting/Snapshotting/CGPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/CGPath.swift
@@ -49,7 +49,7 @@
       }
     }
   }
-#elseif os(iOS) || os(tvOS)
+#elseif os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Snapshotting where Value == CGPath, Format == UIImage {
@@ -91,7 +91,7 @@
   }
 #endif
 
-#if os(macOS) || os(iOS) || os(tvOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
   @available(iOS 11.0, OSX 10.13, tvOS 11.0, *)
   extension Snapshotting where Value == CGPath, Format == String {
     /// A snapshot strategy for comparing bezier paths based on element descriptions.

--- a/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SceneKit.swift
@@ -1,8 +1,8 @@
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
   import SceneKit
   #if os(macOS)
     import Cocoa
-  #elseif os(iOS) || os(tvOS)
+  #elseif os(iOS) || os(tvOS) || os(visionOS)
     import UIKit
   #endif
 
@@ -23,7 +23,7 @@
         return .scnScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
       }
     }
-  #elseif os(iOS) || os(tvOS)
+  #elseif os(iOS) || os(tvOS) || os(visionOS)
     extension Snapshotting where Value == SCNScene, Format == UIImage {
       /// A snapshot strategy for comparing SceneKit scenes based on pixel equality.
       ///

--- a/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SpriteKit.swift
@@ -1,8 +1,8 @@
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
   import SpriteKit
   #if os(macOS)
     import Cocoa
-  #elseif os(iOS) || os(tvOS)
+  #elseif os(iOS) || os(tvOS) || os(visionOS)
     import UIKit
   #endif
 
@@ -23,7 +23,7 @@
         return .skScene(precision: precision, perceptualPrecision: perceptualPrecision, size: size)
       }
     }
-  #elseif os(iOS) || os(tvOS)
+  #elseif os(iOS) || os(tvOS) || os(visionOS)
     extension Snapshotting where Value == SKScene, Format == UIImage {
       /// A snapshot strategy for comparing SpriteKit scenes based on pixel equality.
       ///

--- a/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/SwiftUIView.swift
@@ -4,7 +4,7 @@
 
   /// The size constraint for a snapshot (similar to `PreviewLayout`).
   public enum SwiftUISnapshotLayout {
-    #if os(iOS) || os(tvOS)
+    #if os(iOS) || os(tvOS) || os(visionOS)
       /// Center the view in a device container described by`config`.
       case device(config: ViewImageConfig)
     #endif
@@ -14,8 +14,8 @@
     case sizeThatFits
   }
 
-  #if os(iOS) || os(tvOS)
-    @available(iOS 13.0, tvOS 13.0, *)
+  #if os(iOS) || os(tvOS) || os(visionOS)
+    @available(iOS 13.0, tvOS 13.0, visionOS 1.0, *)
     extension Snapshotting where Value: SwiftUI.View, Format == UIImage {
 
       /// A snapshot strategy for comparing SwiftUI Views based on pixel equality.
@@ -48,7 +48,7 @@
         let config: ViewImageConfig
 
         switch layout {
-        #if os(iOS) || os(tvOS)
+        #if os(iOS) || os(tvOS) || os(visionOS)
           case let .device(config: deviceConfig):
             config = deviceConfig
         #endif
@@ -74,7 +74,7 @@
             let hostingController = UIHostingController.init(rootView: view)
 
             if config.safeArea == .zero {
-              if #available(iOS 16.4, tvOS 16.4, *) {
+              if #available(iOS 16.4, tvOS 16.4, visionOS 1.0, *) {
                 hostingController.safeAreaRegions = []
               } else {
                 hostingController._disableSafeArea = true

--- a/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIBezierPath.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Snapshotting where Value == UIBezierPath, Format == UIImage {

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Diffing where Value == UIImage {
@@ -23,7 +23,19 @@
       if let scale = scale, scale != 0.0 {
         imageScale = scale
       } else {
-        imageScale = UIScreen.main.scale
+        #if os(visionOS)
+          // visionOS has no UIScreen, so there is no screen scale to fall back on. Content
+          // rasterizes at a default @2x scale factor unless a layer opts in to dynamic content
+          // scaling, which doesn't apply to offscreen rendering. See "Drawing sharp layer-based
+          // content in visionOS":
+          // https://developer.apple.com/documentation/visionos/drawing-sharp-layer-based-content
+          //
+          // This matches what 'UIGraphicsImageRenderer' produces there, so a reference decoded at
+          // this scale describes the same point size as the newly-taken snapshot.
+          imageScale = 2.0
+        #else
+          imageScale = UIScreen.main.scale
+        #endif
       }
       let toData: (UIImage) -> Data = { $0.pngData() ?? emptyImage().pngData()! }
       return .diff(
@@ -286,7 +298,7 @@ private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage?
 }
 #endif
 
-#if os(iOS) || os(tvOS) || os(macOS)
+#if os(iOS) || os(tvOS) || os(macOS) || os(visionOS)
   import Accelerate.vImage
   import CoreImage.CIKernel
   import MetalPerformanceShaders

--- a/Sources/SnapshotTesting/Snapshotting/UIView.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIView.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Snapshotting where Value == UIView, Format == UIImage {

--- a/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIViewController.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
   import UIKit
 
   extension Snapshotting where Value == UIViewController, Format == UIImage {


### PR DESCRIPTION
Hi again,

Another contribution today (https://github.com/pointfreeco/swift-snapshot-testing/pull/1114, https://github.com/pointfreeco/swift-snapshot-testing/pull/1115)

This is a resubmission of #855 in the shape requested there.
When closing it, @stephencelis asked for compiler directives only — no device configurations — and 
no visionOS-specific tests or fixtures, and noted being "still down to merge something 
like this in the future". 
Credit to @mihai8804858 for the original work. 

This PR follows that guidance:

- **No `ViewImageConfig` presets** — visionOS windows are freely resizable with no fixed device
  dimensions, so consumers pass their own configs/sizes.
- **No tests or fixtures** — zero changes under `Tests/`; nothing added to repository size.
- **Directives and two small platform branches** — 14 files, +63/−34.

**Commits:**

1. **Add visionOS to the package manifests and platform gates** — `.visionOS(.v1)` in both
   manifests, and `|| os(visionOS)` / `visionOS 1.0` availability added to the existing
   `os(iOS) || os(tvOS)` gates across the UIKit-generic sources.
2. **Fall back to a @2x decode scale for `UIImage` diffing on visionOS** — visionOS has no
   `UIScreen`, so there is no screen scale to read. Content rasterizes at @2x there per Apple's
   ["Drawing sharp layer-based content in visionOS"](https://developer.apple.com/documentation/visionos/drawing-sharp-layer-based-content),
   which also matches what `UIGraphicsImageRenderer` produces, so references decode at the same
   point size the snapshot reports. An explicit `scale:` parameter still wins.
3. **Resolve the key window through connected scenes on visionOS** — `UIApplication.keyWindow` is
   unavailable and `windows` is documented to be empty for scene-based apps, so `getKeyWindow()`
   walks the connected `UIWindowScene`s, with fallbacks.

**Deliberately not enabled:** the `WKWebView` strategies keep their `os(iOS) || os(macOS)` gate.
`takeSnapshot` returns blank images on visionOS, so widening the gate would ship a silently-broken
strategy; better to leave it unavailable until there's a working capture path.

**Validation:** the library and test bundle compile and run on the visionOS 2.5 simulator
(Xcode 16.4) with zero failures — existing device-scale-dependent tests skip via their existing
`GITHUB_WORKFLOW` guard, exactly as on other simulators. The iOS simulator build is unaffected,
and macOS/Linux/Android don't compile any of the gated code. A fork has been running the full
visionOS test suite (with fixtures, on the fork side) green on CI on top of these directives.

---

Thanks for this library — it's been carrying our snapshot coverage across iOS, macOS, and now
visionOS for a while, and the strategy design made extending it to a new platform genuinely
pleasant. 
Happy to adjust anything here to make the merge easy.