### PR TITLE
Fix perceptual comparison for images in different color spaces

### DIFF
--- a/Sources/SnapshotTesting/Snapshotting/NSImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/NSImage.swift
@@ -104,9 +104,18 @@
       return "Newly-taken snapshot does not match reference."
     }
     if perceptualPrecision < 1, #available(macOS 10.13, *) {
+      // Compare the images that were remapped to a common color space above. Passing the original
+      // images here would compare images in different color spaces, which reports a difference on
+      // every pixel even when the images are perceptually identical.
+      guard
+        let oldNormalized = oldContext.makeImage(),
+        let newNormalized = newerContext.makeImage()
+      else {
+        return "Newly-taken snapshot's data could not be loaded."
+      }
       return perceptuallyCompare(
-        CIImage(cgImage: oldCgImage),
-        CIImage(cgImage: newCgImage),
+        CIImage(cgImage: oldNormalized),
+        CIImage(cgImage: newNormalized),
         pixelPrecision: precision,
         perceptualPrecision: perceptualPrecision
       )

--- a/Sources/SnapshotTesting/Snapshotting/UIImage.swift
+++ b/Sources/SnapshotTesting/Snapshotting/UIImage.swift
@@ -130,9 +130,18 @@
       return "Newly-taken snapshot does not match reference."
     }
     if perceptualPrecision < 1, #available(iOS 11.0, tvOS 11.0, *) {
+      // Compare the images that were remapped to a common color space above. Passing the original
+      // images here would compare a Display P3 reference against an extended sRGB snapshot, which
+      // reports a difference on every pixel even when the images are perceptually identical.
+      guard
+        let oldNormalized = context(for: oldCgImage)?.makeImage(),
+        let newNormalized = newerContext.makeImage()
+      else {
+        return "Newly-taken snapshot's data could not be loaded."
+      }
       return perceptuallyCompare(
-        CIImage(cgImage: oldCgImage),
-        CIImage(cgImage: newCgImage),
+        CIImage(cgImage: oldNormalized),
+        CIImage(cgImage: newNormalized),
         pixelPrecision: precision,
         perceptualPrecision: perceptualPrecision
       )
@@ -298,9 +307,18 @@ private func normalizedComponentDiff(_ old: UIImage, _ new: UIImage) -> UIImage?
     // Calculate the deltaE values. Each pixel is a value between 0-100.
     // 0 means no difference, 100 means completely opposite.
     let deltaOutputImage = old.applyingLabDeltaE(new)
-    // Setting the working color space and output color space to NSNull disables color management. This is appropriate when the output
-    // of the operations is computational instead of an image intended to be displayed.
-    let context = CIContext(options: [.workingColorSpace: NSNull(), .outputColorSpace: NSNull()])
+    // Core Image runs filters in the working color space, and its kernels expect those values to be
+    // linear light. Disabling color management (NSNull) leaves gamma-encoded values untouched, so
+    // CILabDeltaE treats them as linear and inflates the difference in dark regions: a single 8-bit
+    // step at black reports 3.54 instead of 0.27. Ask for a linear working space so the sRGB
+    // transfer function is decoded before the delta is computed. The output stays unmanaged because
+    // it is a computed value rather than an image to display.
+    let context = CIContext(
+      options: [
+        .workingColorSpace: CGColorSpace(name: CGColorSpace.extendedLinearSRGB) as Any,
+        .outputColorSpace: NSNull(),
+      ]
+    )
     let deltaThreshold = (1 - perceptualPrecision) * 100
     let actualPixelPrecision: Float
     var maximumDeltaE: Float = 0

--- a/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
+++ b/Tests/SnapshotTestingTests/SnapshotTestingTests.swift
@@ -271,6 +271,100 @@ final class SnapshotTestingTests: BaseTestCase {
     #endif
   }
 
+  func testImagePerceptualPrecisionAcrossColorSpaces() throws {
+    #if os(iOS) || os(tvOS) || os(macOS)
+      guard #available(iOS 11.0, tvOS 11.0, macOS 10.13, *) else { return }
+
+      // A snapshot taken with `drawHierarchyInKeyWindow` comes back in extended sRGB, while the
+      // reference is decoded from PNG as Display P3. Both encode the same color, so the perceptual
+      // comparison has to report no difference. Before the comparison was fed the color-matched
+      // images, every pixel differed and the failure message reported a constant delta unrelated
+      // to the actual contents.
+      let extent = CGRect(x: 0, y: 0, width: 32, height: 32)
+      let color = try XCTUnwrap(
+        CIColor(
+          red: 0.8, green: 0.2, blue: 0.2, colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+      )
+      let ciImage = CIImage(color: color).cropped(to: extent)
+      let context = CIContext()
+      let asDisplayP3 = try XCTUnwrap(
+        context.createCGImage(
+          ciImage, from: extent, format: .RGBA8,
+          colorSpace: CGColorSpace(name: CGColorSpace.displayP3)!)
+      )
+      let asSRGB = try XCTUnwrap(
+        context.createCGImage(
+          ciImage, from: extent, format: .RGBA8,
+          colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!)
+      )
+
+      XCTAssertNil(Self.perceptualDifference(between: asDisplayP3, and: asSRGB))
+    #endif
+  }
+
+  func testImagePerceptualPrecisionInDarkTones() throws {
+    #if os(iOS) || os(tvOS) || os(macOS)
+      guard #available(iOS 11.0, tvOS 11.0, macOS 10.13, *) else { return }
+
+      // A single 8-bit step is imperceptible wherever it occurs, so `perceptualPrecision: 0.99`
+      // (delta <= 1) has to accept it. Core Image runs filters in the working color space and its
+      // kernels expect linear light, so leaving color management disabled makes CILabDeltaE read
+      // gamma-encoded values as linear and inflates dark differences: the same step at black
+      // reports 3.54 instead of 0.27. Anti-aliased edges on a dark background hit exactly this.
+      //
+      // 24 is included on purpose: L* switches from its linear segment to the cube-root one around
+      // there, which is where a single step moves lightness the most.
+      for base in [UInt8(0), 4, 16, 24] {
+        let reference = try Self.solidImage(value: base)
+        let snapshot = try Self.solidImage(value: base + 1)
+        XCTAssertNil(
+          Self.perceptualDifference(between: reference, and: snapshot),
+          "a one-step difference at \(base) should be within the perceptual tolerance"
+        )
+      }
+    #endif
+  }
+
+  #if os(iOS) || os(tvOS) || os(macOS)
+    /// Runs the shipped image diffing with `perceptualPrecision: 0.99` and returns the failure, if any.
+    private static func perceptualDifference(between old: CGImage, and new: CGImage) -> String? {
+      #if os(iOS) || os(tvOS)
+        let strategy = Snapshotting<UIImage, UIImage>.image(perceptualPrecision: 0.99)
+        return strategy.diffing.diffV2(UIImage(cgImage: old), UIImage(cgImage: new))?.0
+      #elseif os(macOS)
+        let strategy = Snapshotting<NSImage, NSImage>.image(perceptualPrecision: 0.99)
+        let size = CGSize(width: old.width, height: old.height)
+        return strategy.diffing.diffV2(
+          NSImage(cgImage: old, size: size), NSImage(cgImage: new, size: size)
+        )?.0
+      #endif
+    }
+
+    private static func solidImage(value: UInt8) throws -> CGImage {
+      let width = 16
+      let height = 16
+      var bytes = [UInt8](repeating: 0, count: width * height * 4)
+      for index in stride(from: 0, to: bytes.count, by: 4) {
+        bytes[index] = value
+        bytes[index + 1] = value
+        bytes[index + 2] = value
+        bytes[index + 3] = 255
+      }
+      let image: CGImage? = bytes.withUnsafeMutableBytes { raw in
+        CGContext(
+          data: raw.baseAddress,
+          width: width,
+          height: height,
+          bitsPerComponent: 8,
+          bytesPerRow: width * 4,
+          space: CGColorSpace(name: CGColorSpace.sRGB)!,
+          bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )?.makeImage()
+      }
+      return try XCTUnwrap(image)
+    }
+  #endif
+
   func testSCNView() {
     // #if os(iOS) || os(macOS) || os(tvOS)
     // // NB: CircleCI crashes while trying to instantiate SCNView.


### PR DESCRIPTION
`perceptualPrecision` stops working when the reference and the snapshot end up in different color spaces. That is what happens with `drawHierarchyInKeyWindow: true`: the reference is decoded from PNG as Display P3, while the snapshot comes back as extended sRGB. Every pixel is then reported as different, and the failure message shows a constant unrelated to the actual contents.

In our project a comparison whose only real difference was a single pixel (ΔE 0.046) reported "The percentage of pixels that match 0.9948387 is less than required 1.0 / The lowest perceptual color precision 0.96484375 is less than required 0.99" — the same two numbers every time, because they come from the color space mismatch rather than from the images.

## Cause

**1. The comparison is handed the un-normalized images**

`compare` already remaps both images to a common color space for the byte comparison, but the perceptual path receives the original `CGImage`s. This is the same problem as #1084 (thanks @TomaszLizer for finding it) — this PR extends the fix to `NSImage`, which routes through the same `perceptuallyCompare`.

**2. Color management is disabled, so gamma values are read as linear**

`CIContext` was created with `workingColorSpace: NSNull()`. Core Image runs filters in the working color space and its kernels expect linear light, so gamma-encoded values are treated as linear and the difference is inflated in dark regions.

A single 8-bit step at black reports a delta of **3.54** (= 903.3 / 255, the L\* difference when the encoded value is taken as luminance) instead of **0.27**, which is what the standard formula gives for (1/255) / 12.92. That is more than enough to fail `perceptualPrecision: 0.99` on an anti-aliased edge over a dark background — exactly the kind of imperceptible jitter the option is meant to absorb.

Asking for a linear working space decodes the transfer function before the delta is computed. The output stays unmanaged, since it is a computed value rather than an image to display.

## Measurements

One 8-bit step, measured on iOS 26.2:

| base | before | after |
| ---- | ------ | ----- |
| 0    | 3.542  | 0.274 |
| 4    | 2.242  | 0.274 |
| 16   | 0.941  | 0.383 |
| 24   | —      | 0.509 |
| 128  | 0.239  | 0.392 |
| 215  | 0.170  | 0.356 |

Before the change the delta depends heavily on lightness; after it, a one-step difference stays in the same range everywhere. base 24 is included because L\* switches from its linear segment to the cube-root one around there, which is where a single step moves lightness the most.

The mid-gray values also line up with the standard formula after the change (2 steps 0.783, 4 steps 1.563, 8 steps 3.118, against 0.75 / 1.54 / 3.10).

## Tests

Two tests are added, both covering iOS and macOS:

- `testImagePerceptualPrecisionAcrossColorSpaces` — the same color encoded as Display P3 and as sRGB has to compare equal.
- `testImagePerceptualPrecisionInDarkTones` — a one-step difference has to stay within tolerance at base 0, 4, 16 and 24.

Both fail without the change (reporting `The percentage of pixels that match 0.0`) and pass with it.

## Verification

Beyond the added tests, I ran this against a project with 346 reference images by running the old and the new comparison on the same capture pairs. No verdict changed. The project's full suite (1400 tests) passes.

On my machine `testNSView`, `testPrecision`, `testWebView` and `testWebViewWithManipulatingNavigationDelegate` fail, but they fail identically with and without this change, so they look environment-related rather than caused by it.

## Note on behavior

This changes what a given `perceptualPrecision` value means, since the delta is no longer inflated in dark regions. Values that were passing because the difference was in a bright area are unaffected; values that were failing on dark anti-aliased edges will now pass, which is the intent.
